### PR TITLE
Send all ERROR log messages back to client

### DIFF
--- a/templates/etc/postgresql/9.3/main/postgresql.conf
+++ b/templates/etc/postgresql/9.3/main/postgresql.conf
@@ -47,7 +47,7 @@ shared_buffers = 128MB
 
 log_line_prefix = '%t '
 log_timezone = 'UTC'
-client_min_messages = FATAL
+client_min_messages = ERROR
 log_min_messages = FATAL
 log_min_error_statement = FATAL
 


### PR DESCRIPTION
This is necessary for some clients (in particular the `bookshelf` Node library) to behave properly on database errors.