### PR TITLE
Dump and restore to and from file

### DIFF
--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -33,13 +33,11 @@ RUN mkdir -p /etc/postgresql/9.4/ssl && cd /etc/postgresql/9.4/ssl && \
 ENV DATA_DIRECTORY /var/db
 RUN mkdir $DATA_DIRECTORY && chown -R postgres $DATA_DIRECTORY
 
+ADD run-database.sh /usr/bin/
+
 ADD test /tmp/test
-RUN su postgres -c "/usr/lib/postgresql/9.4/bin/initdb -D "$DATA_DIRECTORY"" && \
-    bats /tmp/test && \
-    rm -rf "$DATA_DIRECTORY"/*
+RUN bats /tmp/test
 
 VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 5432
-
-ADD run-database.sh /usr/bin/
-ENTRYPOINT ["run-database.sh"]
+ENTRYPOINT ["/usr/bin/run-database.sh"]

--- a/9.4/run-database.sh
+++ b/9.4/run-database.sh
@@ -2,6 +2,8 @@
 
 command="/usr/lib/postgresql/$PG_VERSION/bin/postgres -D "$DATA_DIRECTORY" -c config_file=/etc/postgresql/$PG_VERSION/main/postgresql.conf"
 
+sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" /etc/postgresql/${PG_VERSION}/main/postgresql.conf.erb > /etc/postgresql/${PG_VERSION}/main/postgresql.conf
+
 if [[ "$1" == "--initialize" ]]; then
   chown -R postgres:postgres "$DATA_DIRECTORY"
 

--- a/9.4/run-database.sh
+++ b/9.4/run-database.sh
@@ -19,11 +19,15 @@ elif [[ "$1" == "--client" ]]; then
 
 elif [[ "$1" == "--dump" ]]; then
   [ -z "$2" ] && echo "docker run aptible/postgresql --dump postgresql://... > dump.psql" && exit
-  pg_dump "$2"
+  # If the file /dump-output exists, write output there. Otherwise, use stdout.
+  [ -e /dump-output ] && exec 3>/dump-output || exec 3>&1
+  pg_dump "$2" >&3
 
 elif [[ "$1" == "--restore" ]]; then
   [ -z "$2" ] && echo "docker run -i aptible/postgresql --restore postgresql://... < dump.psql" && exit
-  psql "$2"
+  # If the file /restore-input exists, read input there. Otherwise, use stdin.
+  [ -e /restore-input ] && exec 3</restore-input || exec 3<&0
+  psql "$2" <&3
 
 elif [[ "$1" == "--readonly" ]]; then
   echo "Starting PostgreSQL in read-only mode..."

--- a/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
+++ b/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
@@ -2,7 +2,7 @@
 # FILE LOCATIONS
 #------------------------------------------------------------------------------
 
-data_directory = '/var/db'
+data_directory = 'DATA_DIRECTORY'
 hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'
 ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'
 external_pid_file = '/var/run/postgresql/9.4-main.pid'

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.4.3" {
+@test "It should install PostgreSQL 9.4.5" {
   run /usr/lib/postgresql/9.4/bin/postgres --version
-  [[ "$output" =~ "9.4.3"  ]]
+  [[ "$output" =~ "9.4.5"  ]]
 }

--- a/9.4/test/postgresql-shared.bats
+++ b/9.4/test/postgresql-shared.bats
@@ -1,11 +1,20 @@
 #!/usr/bin/env bats
 
 setup() {
-  /etc/init.d/postgresql start
+  export OLD_DATA_DIRECTORY="$DATA_DIRECTORY"
+  export DATA_DIRECTORY=/tmp/datadir
+  mkdir "$DATA_DIRECTORY"
+  PASSPHRASE=foobar /usr/bin/run-database.sh --initialize
+  /usr/bin/run-database.sh > /tmp/postgres.log 2>&1 &
+  until /etc/init.d/postgresql status; do sleep 0.1; done
 }
 
 teardown() {
   /etc/init.d/postgresql stop
+  while /etc/init.d/postgresql status; do sleep 0.1; done
+  rm -rf "$DATA_DIRECTORY"
+  export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
+  unset OLD_DATA_DIRECTORY
 }
 
 install-heartbleeder() {
@@ -16,6 +25,17 @@ install-heartbleeder() {
 
 uninstall-heartbleeder() {
   rm -rf heartbleeder.zip heartbleeder
+}
+
+@test "It should bring up a working PostgreSQL instance" {
+  su postgres -c "psql --command \"CREATE TABLE foo (i int);\""
+  su postgres -c "psql --command \"INSERT INTO foo VALUES (1234);\""
+  run su postgres -c "psql --command \"SELECT * FROM foo;\""
+  [ "$status" -eq "0" ]
+  [ "${lines[0]}" = "  i   " ]
+  [ "${lines[1]}" = "------" ]
+  [ "${lines[2]}" = " 1234" ]
+  [ "${lines[3]}" = "(1 row)" ]
 }
 
 @test "It should protect against CVE-2014-0160" {
@@ -37,4 +57,44 @@ uninstall-heartbleeder() {
 @test "It should support PostGIS" {
   run su postgres -c "psql --command \"CREATE EXTENSION postgis;\""
   [ "$status" -eq "0" ]
+}
+
+@test "It should dump to stdout by default" {
+  run /usr/bin/run-database.sh --dump postgresql://aptible:foobar@127.0.0.1:5432/db
+  [ "$status" -eq "0" ]
+  [ "${lines[1]}" = "-- PostgreSQL database dump" ]
+  [ "${lines[-2]}" = "-- PostgreSQL database dump complete" ]
+}
+
+@test "It should restore from stdin by default" {
+  /usr/bin/run-database.sh --dump postgresql://aptible:foobar@127.0.0.1:5432/db > /tmp/restore-test
+  echo "CREATE TABLE foo (i int);" >> /tmp/restore-test
+  echo "INSERT INTO foo VALUES (1);" >> /tmp/restore-test
+  run /usr/bin/run-database.sh --restore postgresql://aptible:foobar@127.0.0.1:5432/db < /tmp/restore-test
+  rm /tmp/restore-test
+  [ "$status" -eq "0" ]
+  [ "${lines[-2]}" = "CREATE TABLE" ]
+  [ "${lines[-1]}" = "INSERT 0 1" ]
+}
+
+@test "It should dump to /dump-output if /dump-output exists" {
+  touch /dump-output
+  run /usr/bin/run-database.sh --dump postgresql://aptible:foobar@127.0.0.1:5432/db
+  [ "$status" -eq "0" ]
+  [ "$output" = "" ]
+  run cat dump-output
+  rm /dump-output
+  [ "${lines[1]}" = "-- PostgreSQL database dump" ]
+  [ "${lines[-2]}" = "-- PostgreSQL database dump complete" ]
+}
+
+@test "It should restore from /restore-input if /restore-input exists" {
+  /usr/bin/run-database.sh --dump postgresql://aptible:foobar@127.0.0.1:5432/db > /restore-input
+  echo "CREATE TABLE foo (i int);" >> /restore-input
+  echo "INSERT INTO foo VALUES (1);" >> /restore-input
+  run /usr/bin/run-database.sh --restore postgresql://aptible:foobar@127.0.0.1:5432/db
+  rm /restore-input
+  [ "$status" -eq "0" ]
+  [ "${lines[-2]}" = "CREATE TABLE" ]
+  [ "${lines[-1]}" = "INSERT 0 1" ]
 }


### PR DESCRIPTION
Versions of Docker before 1.6 don't allow you to turn off container logging. On those earlier versions of Docker, you might not want to dump to stdout since the database dump will also show up in the container logs. This patch adds the ability to map in a file to `/dump-output` and, if that file exists, the dump is redirected there instead. I've added a similar mechanism for restore when `/restore-input` exists, so that you can create a named pipe `my-named-pipe` locally, run the dump with `-v my-named-pipe:/dump-output` in the background, and run the restore in the foreground with `-v my-named-pipe:/restore-input` to get the effect of chaining one dump to one restore without the dump output ending up in container logs.

Also adding tests for these scenarios and reworking the existing tests to test against the results of `run-database.sh --initialize` followed by a `run-database.sh` to bring up the server so that we're testing an environment closer to what we actually run with.