### PR TITLE
Replication support for 9.4, with integration tests

### DIFF
--- a/9.3/Dockerfile
+++ b/9.3/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-install locales wget unzip \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
-ADD templates/etc /etc
+ADD templates/etc/apt /etc/apt
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
       B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 && \
     apt-get update && \
@@ -25,6 +25,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
     rm -rf /var/lib/apt/lists/*
 
 # Install self-signed certificate and disallow non-SSL connections
+ADD templates/etc/postgresql /etc/postgresql
 RUN mkdir -p /etc/postgresql/9.3/ssl && cd /etc/postgresql/9.3/ssl && \
     openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 \
       -keyout server.key -subj "/CN=PostgreSQL" -out server.crt && \
@@ -42,4 +43,6 @@ VOLUME ["$DATA_DIRECTORY"]
 EXPOSE 5432
 
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
+
 ENTRYPOINT ["run-database.sh"]

--- a/9.3/run-database.sh
+++ b/9.3/run-database.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
 command="/usr/lib/postgresql/$PG_VERSION/bin/postgres -D "$DATA_DIRECTORY" -c config_file=/etc/postgresql/$PG_VERSION/main/postgresql.conf"
 
 if [[ "$1" == "--initialize" ]]; then
@@ -13,18 +15,33 @@ if [[ "$1" == "--initialize" ]]; then
     /etc/init.d/postgresql stop
 COMMANDS
 
+elif [[ "$1" == "--initialize-follower" ]]; then
+  chown -R postgres:postgres "$DATA_DIRECTORY"
+  chmod 0700 "$DATA_DIRECTORY"
+  su postgres <<COMMANDS
+    pg_basebackup -D $DATA_DIRECTORY -R -d $REPLICATION_URL
+COMMANDS
+
+elif [[ "$1" == "--activate-leader" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/postgresql --activate-leader postgresql://..." && exit 1
+  USERNAME=${REPLICATION_USERNAME:-replicator}
+  PASSPHRASE=${REPLICATION_PASSPHRASE:-$(random_passphrase)}
+  psql "$2" --command "CREATE USER $USERNAME REPLICATION LOGIN ENCRYPTED PASSWORD '$PASSPHRASE'" > /dev/null || exit 1
+  parse_url "$2"
+  echo "REPLICATION_URL=$protocol$USERNAME:$PASSPHRASE@$host_and_port/$database"
+
 elif [[ "$1" == "--client" ]]; then
-  [ -z "$2" ] && echo "docker run -it aptible/postgresql --client postgresql://..." && exit
+  [ -z "$2" ] && echo "docker run -it aptible/postgresql --client postgresql://..." && exit 1
   psql "$2"
 
 elif [[ "$1" == "--dump" ]]; then
-  [ -z "$2" ] && echo "docker run aptible/postgresql --dump postgresql://... > dump.psql" && exit
+  [ -z "$2" ] && echo "docker run aptible/postgresql --dump postgresql://... > dump.psql" && exit 1
   # If the file /dump-output exists, write output there. Otherwise, use stdout.
   [ -e /dump-output ] && exec 3>/dump-output || exec 3>&1
   pg_dump "$2" >&3
 
 elif [[ "$1" == "--restore" ]]; then
-  [ -z "$2" ] && echo "docker run -i aptible/postgresql --restore postgresql://... < dump.psql" && exit
+  [ -z "$2" ] && echo "docker run -i aptible/postgresql --restore postgresql://... < dump.psql" && exit 1
   # If the file /restore-input exists, read input there. Otherwise, use stdin.
   [ -e /restore-input ] && exec 3</restore-input || exec 3<&0
   psql "$2" <&3

--- a/9.3/templates/etc/postgresql/9.3/main/pg_hba.conf
+++ b/9.3/templates/etc/postgresql/9.3/main/pg_hba.conf
@@ -1,2 +1,3 @@
-local     all   all                        peer
-hostssl   all   all        0.0.0.0/0       md5
+local     all           all               peer
+hostssl   all           all   0.0.0.0/0   md5
+hostssl   replication   all   0.0.0.0/0   md5

--- a/9.3/templates/etc/postgresql/9.3/main/postgresql.conf
+++ b/9.3/templates/etc/postgresql/9.3/main/postgresql.conf
@@ -35,6 +35,11 @@ shared_buffers = 128MB
 # REPLICATION
 #------------------------------------------------------------------------------
 
+wal_level = hot_standby
+max_wal_senders = 3
+checkpoint_segments = 8
+wal_keep_segments = 8
+hot_standby = on
 
 #------------------------------------------------------------------------------
 # QUERY TUNING

--- a/9.3/utilities.sh
+++ b/9.3/utilities.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}
+
+random_passphrase()
+{
+  head -c 20 /dev/urandom | base64 | tr -d '/'
+}

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-install locales wget unzip \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
-ADD templates/etc /etc
+ADD templates/etc/apt /etc/apt
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
       B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 && \
     apt-get update && \
@@ -28,6 +28,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys \
     rm -rf /var/lib/apt/lists/*
 
 # Install self-signed certificate and disallow non-SSL connections
+ADD templates/etc/postgresql /etc/postgresql
 RUN mkdir -p /etc/postgresql/9.4/ssl && cd /etc/postgresql/9.4/ssl && \
     openssl req -new -newkey rsa:1024 -days 365000 -nodes -x509 \
       -keyout server.key -subj "/CN=PostgreSQL" -out server.crt && \
@@ -37,6 +38,7 @@ ENV DATA_DIRECTORY /var/db
 RUN mkdir $DATA_DIRECTORY && chown -R postgres $DATA_DIRECTORY
 
 ADD run-database.sh /usr/bin/
+ADD utilities.sh /usr/bin/
 
 ADD test /tmp/test
 RUN bats /tmp/test

--- a/9.4/Dockerfile
+++ b/9.4/Dockerfile
@@ -10,6 +10,9 @@ RUN groupadd -r postgres && useradd -r -g postgres postgres
 # See https://github.com/docker/docker/issues/6345 for details.
 RUN ln -s -f /bin/true /usr/bin/chfn
 
+# Install Ruby, for ERB
+RUN apt-install ruby
+
 # Install PostgreSQL 9.4.x from official Debian sources
 RUN apt-install locales wget unzip \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8

--- a/9.4/run-database.sh
+++ b/9.4/run-database.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
+. /usr/bin/utilities.sh
+
 command="/usr/lib/postgresql/$PG_VERSION/bin/postgres -D "$DATA_DIRECTORY" -c config_file=/etc/postgresql/$PG_VERSION/main/postgresql.conf"
 
-sed "s:DATA_DIRECTORY:${DATA_DIRECTORY}:g" /etc/postgresql/${PG_VERSION}/main/postgresql.conf.erb > /etc/postgresql/${PG_VERSION}/main/postgresql.conf
+if [ ! -f /etc/postgresql/${PG_VERSION}/main/postgresql.conf ]; then
+  erb /etc/postgresql/${PG_VERSION}/main/postgresql.conf.erb > /etc/postgresql/${PG_VERSION}/main/postgresql.conf
+fi
 
 if [[ "$1" == "--initialize" ]]; then
   chown -R postgres:postgres "$DATA_DIRECTORY"
@@ -15,18 +19,33 @@ if [[ "$1" == "--initialize" ]]; then
     /etc/init.d/postgresql stop
 COMMANDS
 
+elif [[ "$1" == "--initialize-follower" ]]; then
+  chown -R postgres:postgres "$DATA_DIRECTORY"
+  chmod 0700 "$DATA_DIRECTORY"
+  su postgres <<COMMANDS
+    pg_basebackup -D $DATA_DIRECTORY -R -d $REPLICATION_URL
+COMMANDS
+
+elif [[ "$1" == "--activate-leader" ]]; then
+  [ -z "$2" ] && echo "docker run -it aptible/postgresql --activate-leader postgresql://..." && exit 1
+  USERNAME=${REPLICATION_USERNAME:-replicator}
+  PASSPHRASE=${REPLICATION_PASSPHRASE:-$(random_passphrase)}
+  psql "$2" --command "CREATE USER $USERNAME REPLICATION LOGIN ENCRYPTED PASSWORD '$PASSPHRASE'" > /dev/null || exit 1
+  parse_url "$2"
+  echo "REPLICATION_URL=$protocol$USERNAME:$PASSPHRASE@$host_and_port/$database"
+
 elif [[ "$1" == "--client" ]]; then
-  [ -z "$2" ] && echo "docker run -it aptible/postgresql --client postgresql://..." && exit
+  [ -z "$2" ] && echo "docker run -it aptible/postgresql --client postgresql://..." && exit 1
   psql "$2"
 
 elif [[ "$1" == "--dump" ]]; then
-  [ -z "$2" ] && echo "docker run aptible/postgresql --dump postgresql://... > dump.psql" && exit
+  [ -z "$2" ] && echo "docker run aptible/postgresql --dump postgresql://... > dump.psql" && exit 1
   # If the file /dump-output exists, write output there. Otherwise, use stdout.
   [ -e /dump-output ] && exec 3>/dump-output || exec 3>&1
   pg_dump "$2" >&3
 
 elif [[ "$1" == "--restore" ]]; then
-  [ -z "$2" ] && echo "docker run -i aptible/postgresql --restore postgresql://... < dump.psql" && exit
+  [ -z "$2" ] && echo "docker run -i aptible/postgresql --restore postgresql://... < dump.psql" && exit 1
   # If the file /restore-input exists, read input there. Otherwise, use stdin.
   [ -e /restore-input ] && exec 3</restore-input || exec 3<&0
   psql "$2" <&3

--- a/9.4/templates/etc/postgresql/9.4/main/pg_hba.conf
+++ b/9.4/templates/etc/postgresql/9.4/main/pg_hba.conf
@@ -1,2 +1,3 @@
-local     all   all                        peer
-hostssl   all   all        0.0.0.0/0       md5
+local     all           all               peer
+hostssl   all           all   0.0.0.0/0   md5
+hostssl   replication   all   0.0.0.0/0   md5

--- a/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
+++ b/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
@@ -35,6 +35,11 @@ shared_buffers = 128MB
 # REPLICATION
 #------------------------------------------------------------------------------
 
+wal_level = hot_standby
+max_wal_senders = 3
+checkpoint_segments = 8
+wal_keep_segments = 8
+hot_standby = on
 
 #------------------------------------------------------------------------------
 # QUERY TUNING

--- a/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
+++ b/9.4/templates/etc/postgresql/9.4/main/postgresql.conf.erb
@@ -2,7 +2,7 @@
 # FILE LOCATIONS
 #------------------------------------------------------------------------------
 
-data_directory = 'DATA_DIRECTORY'
+data_directory = '<%= ENV["DATA_DIRECTORY"] %>'
 hba_file = '/etc/postgresql/9.4/main/pg_hba.conf'
 ident_file = '/etc/postgresql/9.4/main/pg_ident.conf'
 external_pid_file = '/var/run/postgresql/9.4-main.pid'

--- a/9.4/test/postgresql-shared.bats
+++ b/9.4/test/postgresql-shared.bats
@@ -15,6 +15,7 @@ teardown() {
   rm -rf "$DATA_DIRECTORY"
   export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
   unset OLD_DATA_DIRECTORY
+  rm -f /etc/postgresql/${PG_VERSION}/main/postgresql.conf
 }
 
 install-heartbleeder() {

--- a/9.4/test/postgresql-shared.bats
+++ b/9.4/test/postgresql-shared.bats
@@ -98,3 +98,35 @@ uninstall-heartbleeder() {
   [ "${lines[-2]}" = "CREATE TABLE" ]
   [ "${lines[-1]}" = "INSERT 0 1" ]
 }
+
+@test "It should create a replication user and print a connection URL" {
+  run /usr/bin/run-database.sh --activate-leader postgresql://aptible:foobar@127.0.0.1:5432/db
+  [ "$status" -eq "0" ]
+  run psql --command '\dt' $output
+}
+
+@test "It should set up a follower" {
+  export FOLLOWER_DIRECTORY=/tmp/follower
+  mkdir -p $FOLLOWER_DIRECTORY
+
+  export $(/usr/bin/run-database.sh --activate-leader postgresql://aptible:foobar@127.0.0.1:5432/db)
+  DATA_DIRECTORY=$FOLLOWER_DIRECTORY /usr/bin/run-database.sh --initialize-follower
+  su postgres -c "/usr/lib/postgresql/$PG_VERSION/bin/postgres -D "$FOLLOWER_DIRECTORY" \
+                  -c config_file=/etc/postgresql/$PG_VERSION/main/postgresql.conf \
+                  -c port=5433 -c data_directory=$FOLLOWER_DIRECTORY \
+                  -c external_pid_file=$FOLLOWER_DIRECTORY/9.4-main.pid" &
+  until su postgres -c "psql --command '\dt' -p 5433"; do sleep 0.1; done
+
+  su postgres -c "psql -p 5432 --command \"CREATE TABLE foo (i int);\""
+  su postgres -c "psql -p 5432 --command \"INSERT INTO foo VALUES (1234);\""
+  until su postgres -c "psql -p 5433 --command \"SELECT * FROM foo;\""; do sleep 0.1; done
+  run su postgres -c "psql -p 5433 --command \"SELECT * FROM foo;\""
+  [ "$status" -eq "0" ]
+  [ "${lines[0]}" = "  i   " ]
+  [ "${lines[1]}" = "------" ]
+  [ "${lines[2]}" = " 1234" ]
+  [ "${lines[3]}" = "(1 row)" ]
+
+  kill $(cat $FOLLOWER_DIRECTORY/9.4-main.pid)
+  rm -rf $FOLLOWER_DIRECTORY
+}

--- a/9.4/utilities.sh
+++ b/9.4/utilities.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+parse_url()
+{
+  # cf http://stackoverflow.com/a/17287984
+  protocol="$(echo "$1" | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+  # remove the protocol
+  url=$(echo $1 | sed -e s,$protocol,,g)
+  # extract the user and password (if any)
+  user_and_password="$(echo $url | grep @ | cut -d@ -f1)"
+  password="$(echo $user_and_password | grep : | cut -d: -f2)"
+  if [ -n "$password" ]; then
+    user="$(echo $user_and_password | grep : | cut -d: -f1)"
+  else
+    user="$user_and_password"
+  fi
+
+  # extract the host
+  host_and_port="$(echo $url | sed -e s,$user_and_password@,,g | cut -d/ -f1)"
+  port="$(echo $host_and_port | grep : | cut -d: -f2)"
+  if [ -n "$port" ]; then
+    host="$(echo $host_and_port | grep : | cut -d: -f1)"
+  else
+    host="$host_and_port"
+  fi
+
+  database="$(echo $url | grep / | cut -d/ -f2-)"
+}
+
+random_passphrase()
+{
+  head -c 20 /dev/urandom | base64 | tr -d '/'
+}


### PR DESCRIPTION
This PR introduces a new API for administering replication via a read-write "leader" and read-only "follower." Specifically, the standardized workflow for promoting an existing standalone database to a leader, and creating a new follower database, is:

1. Activate leader: Run a container with `--activate-leader LEADER_URL`, also mounting the data volumes of the leader container. This allows for enabling replication either remotely (by the LEADER_URL), or by directly accessing the leader's filesystem. This operation should print all necessary configuration variables to be loaded in (via ENV) to initialize the follower in the next step.
2. Initialize follower: Run a container with `--initialize-follower`, in the same way you'd run `--initialize` on a standalone database. Mount a new set of data volumes for this container, and include all ENV variables printed by `--activate-leader` in the previous step.
3. Start follower: Run a container with no arguments, mounting the data volumes of the follower created in the previous step.

On PostgreSQL, these operations are implemented as follows:

1. Activate leader: Create a new replication-only user, and print its connection URL as `REPLICATION_URL`.
2. Initialize follower: Run pg_basebackup and create a recovery.conf file.
3. Start follower: No special implementation. A PostgreSQL database "knows" whether it is a leader or follower.
