### PR TITLE
Add support for Postgres 9.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     - TAG=9.3
     - TAG=9.4
+    - TAG=9.5
 
 script:
   - make build

--- a/9.3/config.mk
+++ b/9.3/config.mk
@@ -1,1 +1,2 @@
 export POSTGRES_VERSION = 9.3
+export POSTGIS_VERSION = 2.1

--- a/9.4/config.mk
+++ b/9.4/config.mk
@@ -1,2 +1,2 @@
 export POSTGRES_VERSION = 9.4
-
+export POSTGIS_VERSION = 2.1

--- a/9.5/config.mk
+++ b/9.5/config.mk
@@ -1,0 +1,2 @@
+export POSTGRES_VERSION = 9.5
+export POSTGIS_VERSION = 2.2

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "It should install PostgreSQL 9.5.0" {
+  run /usr/lib/postgresql/9.5/bin/postgres --version
+  [[ "$output" =~ "9.5.0"  ]]
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -2,6 +2,7 @@ FROM quay.io/aptible/debian:wheezy
 
 # Define PostgreSQL version for shared scripts
 ENV PG_VERSION <%= ENV.fetch 'POSTGRES_VERSION' %>
+ENV POSTGIS_VERSION <%= ENV.fetch 'POSTGIS_VERSION' %>
 
 # cf. docker-library/postgres: explicitly create the user so uid and gid are consistent.
 RUN groupadd -r postgres && useradd -r -g postgres postgres
@@ -18,15 +19,26 @@ ENV LANG en_US.utf8
 # And now install Postgres from its own repos
 ADD templates/etc/apt /etc/apt
 
+
+# The package names below are anchored, becuase they're interpreted by apt as regexes
+# (because they contain "."), which can result in undesired packages being installed if
+# we don't update the PG and PostGIS versions properly, e.g.:
+# $ sudo apt-get install -y postgresql-9.5-postgis-2.1
+# Reading package lists... Done
+# Building dependency tree
+# Reading state information... Done
+# Note, selecting 'postgresql-9.5-postgis-2.1-scripts' for regex 'postgresql-9.5-postgis-2.1'
+# 0 upgraded, 0 newly installed, 0 to remove and 20 not upgraded.
+
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
  && apt-get update \
  && apt-get -y install postgresql-common \
  && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
  && apt-get -y install \
-    "postgresql-$PG_VERSION" \
-    "postgresql-client-$PG_VERSION" \
-    "postgresql-contrib-$PG_VERSION" \
-    "postgresql-$PG_VERSION-postgis-2.1" \
+    "^postgresql-${PG_VERSION}\$" \
+    "^postgresql-client-${PG_VERSION}\$" \
+    "^postgresql-contrib-${PG_VERSION}\$" \
+    "^postgresql-${PG_VERSION}-postgis-${POSTGIS_VERSION}\$" \
  && rm -rf /var/lib/apt/lists/*
 
 ENV CONF_DIRECTORY /etc/postgresql/$PG_VERSION

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ The PostgreSQL server is configured to enforce SSL for any TCP connection. It us
 
 ## Available Versions (Tags)
 
-* `latest`: Currently PostgreSQL 9.4.5
+* `latest`: Currently PostgreSQL 9.5.0
+* `9.5`: PostgreSQL 9.5.0
 * `9.4`: PostgreSQL 9.4.5
 * `9.3`: PostgreSQL 9.3.10
 

--- a/latest.mk
+++ b/latest.mk
@@ -1,2 +1,2 @@
-LATEST_TAG = 9.4
+LATEST_TAG = 9.5
 

--- a/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
+++ b/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
@@ -37,9 +37,12 @@ shared_buffers = 128MB
 
 wal_level = hot_standby
 max_wal_senders = 3
-checkpoint_segments = 8
 wal_keep_segments = 8
 hot_standby = on
+
+# Checkpointing configuration is required on PG < 9.5. However, 9.5 has smarter
+# defaults, so we don't have it there.
+checkpoint_segments = 8  # __NOT_IF_PG_9.5__
 
 #------------------------------------------------------------------------------
 # QUERY TUNING


### PR DESCRIPTION
Two main differences with 9.4:

- PostGIS is now version 2.2
- We no longer set checkpoint_segments, because that option is gone. We
  don't set a replacement (e.g. `max_wal_size`) because Postgres 9.5 is
  apparently smarter about choosing defaults here.

cc @fancyremarker 