### PR TITLE
Fix tests to work on Docker 1.10

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -33,7 +33,7 @@ echo "Initializing replication master"
 
 MASTER_PORT=54321
 
-docker run -it --rm \
+docker run -i --rm \
   -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
   --volumes-from "$MASTER_DATA_CONTAINER" \
   "$IMG" --initialize
@@ -43,7 +43,7 @@ docker run -d --name="$MASTER_CONTAINER" \
   --volumes-from "$MASTER_DATA_CONTAINER" \
   "$IMG"
 
-until docker exec -it "$MASTER_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
+until docker exec -i "$MASTER_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
 
 MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
 MASTER_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
@@ -51,14 +51,14 @@ MASTER_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
 
 echo "Creating test_before table"
 
-docker run -it --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_before (col TEXT);"
-docker run -it --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_before (col TEXT);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
 
 
 echo "Initializing replication slave"
 SLAVE_PORT=54322
 
-docker run -it --rm \
+docker run -i --rm \
   --volumes-from "$SLAVE_DATA_CONTAINER" \
   "$IMG" --initialize-from "$MASTER_URL"   # TODO - Is this even gonna work?
 
@@ -73,17 +73,17 @@ SLAVE_URL="postgresql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
 
 
 # Wait for slave to come up
-until docker exec -it "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
+until docker exec -i "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
 
 # Create a test table now that replication has started
-docker run -it --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT);"
-docker run -it --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
 
 # Give replication a little time. (Hopefully) much more than needed!
 sleep 1
 
 # Check that data is present in both tables
-docker run -it --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
-docker run -it --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
+docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
+docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
 
 echo "Test OK!"


### PR DESCRIPTION
If we use the `-t` flag, the steps where we run `grep '...'` hang
(unless we kill the container). Removing tty mode (which we don't need
here anyway) ensures they complete properly.