### PR TITLE
Ensure correct permissions/ownership on /var/db

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -106,6 +106,7 @@ elif [[ "$1" == "--readonly" ]]; then
 
 else
   pg_init_conf
+  pg_init_data
   pg_run_server
 
 fi


### PR DESCRIPTION
Hi there,

After bringing the container down with `docker-compose down`, PostgreSQL fails to start on subsequent runs because the data directory permissions are no longer valid. I think this is because after the first run, the volume is then a "docker controlled volume" which is created in `/var/lib/docker`. Not totally sure, though. This PR adds `pg_init_data` to the normal server run process, like the other arguments in `run-database.sh`, to ensure `/var/db` always has the correct ownership and permissions.
### Steps to reproduce:
1. Initialize the container (via `--initialize`)
2. Run `docker-compose down`
3. Run `docker-compose up`
### Expected:
- Postgres container starts in the foreground
### Actual:
- Fatal error due to `/var/db` permissions:

```
Creating able_postgres_1
Attaching to able_postgres_1
postgres_1  | Generating a 1024 bit RSA private key
postgres_1  | .........++++++
postgres_1  | ...................++++++
postgres_1  | writing new private key to 'server.key'
postgres_1  | -----
postgres_1  | Running PG with options:
postgres_1  | 2016-04-24 00:40:54 UTC FATAL:  data directory "/var/db" has group or world access
postgres_1  | 2016-04-24 00:40:54 UTC DETAIL:  Permissions should be u=rwx (0700).
able_postgres_1 exited with code 1
```

Permissions after container `--initialize`:

```
root@e510f7327eae:/var# ls -la
total 8
drwxr-xr-x 1 root     root      94 Apr 23 23:42 .
drwxr-xr-x 1 root     root     222 Apr 24 00:34 ..
drwx------ 1 postgres postgres 514 Apr 24 00:14 db
```

Wrong permissions after `docker-compose down; docker-compose up`:

```
root@e510f7327eae:/var# ls -la
total 8
drwxr-xr-x 1 root     root      94 Apr 23 23:42 .
drwxr-xr-x 1 root     root     222 Apr 24 00:34 ..
drwxr-xr-x 1 postgres root  514 Apr 24 00:38 db
```
