### PR TITLE
Captain comeback support  (Support clean restarts)

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,11 +1,26 @@
 FROM quay.io/aptible/debian:wheezy
 
+# cf. docker-library/postgres: explicitly create the user so uid and gid are consistent.
+RUN groupadd -r postgres && useradd -r -g postgres postgres
+
+# Grab gosu: we'll need to step down from root and would rather not have to deal with sudo's
+# awkwardness.
+ENV GOSU_VERSION 1.7
+RUN set -x \
+ && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+ && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+ && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+ && export GNUPGHOME="$(mktemp -d)" \
+ && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+ && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+ && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+ && chmod +x /usr/local/bin/gosu \
+ && gosu nobody true \
+ && apt-get purge -y --auto-remove ca-certificates wget
+
 # Define PostgreSQL version for shared scripts
 ENV PG_VERSION <%= ENV.fetch 'POSTGRES_VERSION' %>
 ENV POSTGIS_VERSION <%= ENV.fetch 'POSTGIS_VERSION' %>
-
-# cf. docker-library/postgres: explicitly create the user so uid and gid are consistent.
-RUN groupadd -r postgres && useradd -r -g postgres postgres
 
 # Temporary workaround for host-container user conflicts on Linux Kernel >= 3.15
 # See https://github.com/docker/docker/issues/6345 for details.

--- a/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
+++ b/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
@@ -56,8 +56,9 @@ checkpoint_segments = 8  # __NOT_IF_PG_9.5__
 log_line_prefix = '%t '
 log_timezone = 'UTC'
 client_min_messages = ERROR
-log_min_messages = FATAL
+log_min_messages = INFO
 log_min_error_statement = FATAL
+log_destination = 'stderr'
 
 #------------------------------------------------------------------------------
 # RUNTIME STATISTICS

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+MASTER_CONTAINER="postgres-master"
+MASTER_DATA_CONTAINER="${MASTER_CONTAINER}-data"
+SLAVE_CONTAINER="postgres-slave"
+SLAVE_DATA_CONTAINER="${SLAVE_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$MASTER_CONTAINER" "$MASTER_DATA_CONTAINER" "$SLAVE_CONTAINER" "$SLAVE_DATA_CONTAINER" || true
+}
+
+trap cleanup EXIT
+cleanup
+
+USER=testuser
+PASSPHRASE=testpass
+DATABASE=testdb
+
+
+echo "Initializing data containers"
+
+docker create --name "$MASTER_DATA_CONTAINER" "$IMG"
+docker create --name "$SLAVE_DATA_CONTAINER" "$IMG"
+
+
+echo "Initializing replication master"
+
+MASTER_PORT=54321
+
+docker run -i --rm \
+  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
+  --volumes-from "$MASTER_DATA_CONTAINER" \
+  "$IMG" --initialize
+
+docker run -d --name="$MASTER_CONTAINER" \
+  -e "PORT=${MASTER_PORT}" \
+  --volumes-from "$MASTER_DATA_CONTAINER" \
+  "$IMG"
+
+until docker exec -i "$MASTER_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
+
+MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
+MASTER_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
+
+
+echo "Creating test_before table"
+
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_before (col TEXT);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
+
+
+echo "Initializing replication slave"
+SLAVE_PORT=54322
+
+docker run -i --rm \
+  --volumes-from "$SLAVE_DATA_CONTAINER" \
+  "$IMG" --initialize-from "$MASTER_URL"   # TODO - Is this even gonna work?
+
+docker run -d --name "$SLAVE_CONTAINER" \
+  -e "PORT=${SLAVE_PORT}" \
+  --volumes-from "$SLAVE_DATA_CONTAINER" \
+  "$IMG"
+
+
+SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
+SLAVE_URL="postgresql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
+
+
+# Wait for slave to come up
+until docker exec -i "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
+
+# Create a test table now that replication has started
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
+
+# Give replication a little time. (Hopefully) much more than needed!
+sleep 1
+
+# Check that data is present in both tables
+docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
+docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
+
+echo "Test OK!"

--- a/test-restart.sh
+++ b/test-restart.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+IMG="$1"
+
+PG_CONTAINER="postgres"
+DATA_CONTAINER="${PG_CONTAINER}-data"
+
+function cleanup {
+  echo "Cleaning up"
+  docker rm -f "$PG_CONTAINER" "$DATA_CONTAINER" >/dev/null 2>&1 || true
+}
+
+function wait_for_pg {
+  for _ in $(seq 1 1000); do
+    if docker exec -it "$PG_CONTAINER" gosu postgres psql db -c 'SELECT 1;' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+
+  echo "DB never came online"
+  docker logs "$PG_CONTAINER"
+  return 1
+}
+
+trap cleanup EXIT
+cleanup
+
+echo "Creating data container"
+docker create --name "$DATA_CONTAINER" "$IMG"
+
+echo "Starting DB"
+docker run -it --rm \
+  -e USERNAME=user -e PASSPHRASE=pass -e DATABASE=db \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG" --initialize \
+  >/dev/null 2>&1
+
+docker run -d --name="$PG_CONTAINER" \
+  -e EXPOSE_HOST=127.0.0.1 -e EXPOSE_PORT_27217=27217 \
+  --volumes-from "$DATA_CONTAINER" \
+  "$IMG"
+
+echo "Waiting for DB to come online"
+wait_for_pg
+
+echo "Verifying DB shutdown message isn't present"
+docker logs "$PG_CONTAINER" 2>&1 | grep -vqi "database system is shut down"
+
+echo "Restarting DB container"
+date
+docker top "$PG_CONTAINER"
+docker restart -t 10 "$PG_CONTAINER"
+
+echo "Waiting for DB to come back online"
+wait_for_pg
+
+echo "DB came back online; checking for clean shutdown and recovery"
+date
+docker logs "$PG_CONTAINER" 2>&1 | grep -qi "database system is shut down"
+docker logs "$PG_CONTAINER" 2>&1 | grep -vqi "database system was not properly shut down"
+
+echo "Attempting unclean shutdown"
+docker kill -s KILL "$PG_CONTAINER"
+docker start "$PG_CONTAINER"
+
+echo "Waiting for DB to come back online"
+wait_for_pg
+
+docker logs "$PG_CONTAINER" 2>&1 | grep -qi "database system was not properly shut down"

--- a/test.sh
+++ b/test.sh
@@ -2,88 +2,11 @@
 set -o errexit
 set -o nounset
 
-
 IMG="$REGISTRY/$REPOSITORY:$TAG"
 
-MASTER_CONTAINER="postgres-master"
-MASTER_DATA_CONTAINER="${MASTER_CONTAINER}-data"
-SLAVE_CONTAINER="postgres-slave"
-SLAVE_DATA_CONTAINER="${SLAVE_CONTAINER}-data"
+./test-restart.sh "$IMG"
+./test-replication.sh "$IMG"
 
-function cleanup {
-  echo "Cleaning up"
-  docker rm -f "$MASTER_CONTAINER" "$MASTER_DATA_CONTAINER" "$SLAVE_CONTAINER" "$SLAVE_DATA_CONTAINER" || true
-}
-
-trap cleanup EXIT
-cleanup
-
-USER=testuser
-PASSPHRASE=testpass
-DATABASE=testdb
-
-
-echo "Initializing data containers"
-
-docker create --name "$MASTER_DATA_CONTAINER" "$IMG"
-docker create --name "$SLAVE_DATA_CONTAINER" "$IMG"
-
-
-echo "Initializing replication master"
-
-MASTER_PORT=54321
-
-docker run -i --rm \
-  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
-  --volumes-from "$MASTER_DATA_CONTAINER" \
-  "$IMG" --initialize
-
-docker run -d --name="$MASTER_CONTAINER" \
-  -e "PORT=${MASTER_PORT}" \
-  --volumes-from "$MASTER_DATA_CONTAINER" \
-  "$IMG"
-
-until docker exec -i "$MASTER_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
-
-MASTER_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$MASTER_CONTAINER")"
-MASTER_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$DATABASE"
-
-
-echo "Creating test_before table"
-
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_before (col TEXT);"
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
-
-
-echo "Initializing replication slave"
-SLAVE_PORT=54322
-
-docker run -i --rm \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG" --initialize-from "$MASTER_URL"   # TODO - Is this even gonna work?
-
-docker run -d --name "$SLAVE_CONTAINER" \
-  -e "PORT=${SLAVE_PORT}" \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG"
-
-
-SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
-SLAVE_URL="postgresql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
-
-
-# Wait for slave to come up
-until docker exec -i "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
-
-# Create a test table now that replication has started
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT);"
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
-
-# Give replication a little time. (Hopefully) much more than needed!
-sleep 1
-
-# Check that data is present in both tables
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
-
-echo "Test OK!"
+echo "#############"
+echo "# Tests OK! #"
+echo "#############"


### PR DESCRIPTION
We currently run a shell as PID 1, and then use sudo to run Postgres.
Running a shell is bad because it means all signals are lost (including
the SIGTERM sent by `docker restart`), and using sudo is bad because we
can't really ever know for sure what happens to signals or the
environment.

All in all, this patch ensures PG runs as PID 1 and adds a test to make
sure it restarts cleanly on a `docker restart`.

This also increases the Postgres log level to INFO, so that we can
capture log messages to know what Postgres is doing (and also because
it's good to hear about warnings and so on).

--

cc @fancyremarker @blakepettersson 