### PR TITLE
Backport contrib packages to 9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 env:
   matrix:
     - TAG=9.3
+    - TAG=9.3-contrib
     - TAG=9.4
     - TAG=9.4-contrib
     - TAG=9.5

--- a/9.3-contrib/config.mk
+++ b/9.3-contrib/config.mk
@@ -1,0 +1,2 @@
+export POSTGRES_VERSION = 9.3
+export POSTGIS_VERSION = 2.1

--- a/9.3-contrib/install-extras.sh
+++ b/9.3-contrib/install-extras.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+# Install packaged extensions first
+apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$"
+
+# Now, install source extensions
+
+# We'll need backports for libv8
+echo "deb http://httpredir.debian.org/debian wheezy-backports main" >> /etc/apt/sources.list
+
+DEPS=(
+  build-essential python-pip
+  libpq-dev "^postgresql-server-dev-${PG_VERSION}$"
+  freetds-dev
+  libv8-3.14-dev
+  libmysqlclient-dev
+  python-dev
+)
+
+apt-install "${DEPS[@]}"
+pip install pgxnclient
+
+pgxn install "tds_fdw==1.0.7"
+pgxn install "plv8==1.4.4"
+pgxn install --testing "pg_proctab==0.0.5"
+USE_PGXS=1 pgxn install "mysql_fdw==2.1.2"
+pgxn install "multicorn==1.3.3"

--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -1,0 +1,42 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should install PostgreSQL 9.3.15" {
+  run /usr/lib/postgresql/9.3/bin/postgres --version
+  [[ "$output" =~ "9.3.15"  ]]
+}
+
+@test "It should support PLV8" {
+  sudo -u postgres psql --command "CREATE EXTENSION plv8;"
+  sudo -u postgres psql --command "CREATE EXTENSION plls;"
+  sudo -u postgres psql --command "CREATE EXTENSION plcoffee;"
+}
+
+@test "It should support tds_fdw" {
+  sudo -u postgres psql --command "CREATE EXTENSION tds_fdw;"
+}
+
+@test "It should support pg_proctab" {
+  sudo -u postgres psql --command "CREATE EXTENSION pg_proctab;"
+}
+
+@test "It should support plpythonu" {
+  sudo -u postgres psql --command "CREATE EXTENSION plpythonu;"
+}
+
+@test "It should support plpython2u" {
+  sudo -u postgres psql --command "CREATE EXTENSION plpython2u;"
+}
+
+@test "It should support plpython3u" {
+  sudo -u postgres psql --command "CREATE EXTENSION plpython3u;"
+}
+
+@test "It should support mysql_fdw" {
+  sudo -u postgres psql --command "CREATE EXTENSION mysql_fdw;"
+}
+
+@test "It should support multicorn" {
+  sudo -u postgres psql --command "CREATE EXTENSION multicorn;"
+}


### PR DESCRIPTION
A customer would like to run pg_stat_statements and friends while
they're still on 9.3. This adds the contrib tag for Postgres 9.3.x

cc @fancyremarker @krallin 