### PR TITLE
Add pglogical extension

### DIFF
--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -2,9 +2,15 @@
 set -o errexit
 set -o nounset
 
+# We'll need the pglogical repo...
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+
+# ...and its key
+apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
+
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
-  "^postgresql-plperl-${PG_VERSION}$"
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$"
 
 # Now, install source extensions
 

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -58,3 +58,12 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE LANGUAGE plperlu;"
 }
+
+@test "It should support pglogical" {
+  dpkg-query -l postgresql-${PG_VERSION}-pglogical
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pglogical';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical_origin;"
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
+}

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -2,9 +2,15 @@
 set -o errexit
 set -o nounset
 
+# We'll need the pglogical repo...
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+
+# ...and its key
+apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
+
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
-  "^postgresql-plperl-${PG_VERSION}$"
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$"
 
 # Now, install source extensions
 

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -53,3 +53,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE LANGUAGE plperlu;"
 }
+
+@test "It should support pglogical" {
+  dpkg-query -l postgresql-${PG_VERSION}-pglogical
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pglogical';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
+}

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -2,9 +2,15 @@
 set -o errexit
 set -o nounset
 
+# We'll need the pglogical repo...
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+
+# ...and its key
+apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
+
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
-  "^postgresql-plperl-${PG_VERSION}$"
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$"
 
 # Now, install source extensions
 

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -43,3 +43,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE LANGUAGE plperlu;"
 }
+
+@test "It should support pglogical" {
+  dpkg-query -l postgresql-${PG_VERSION}-pglogical
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pglogical';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
+}

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -9,8 +9,7 @@ setup() {
 }
 
 teardown() {
-  /etc/init.d/postgresql stop || true
-  while /etc/init.d/postgresql status; do sleep 0.1; done
+  stop_pg
 
   rm -rf "$DATA_DIRECTORY"
   export DATA_DIRECTORY="$OLD_DATA_DIRECTORY"
@@ -25,12 +24,26 @@ teardown() {
 
 initialize_and_start_pg() {
   PASSPHRASE=foobar /usr/bin/run-database.sh --initialize
-  /usr/bin/run-database.sh > /tmp/postgres.log 2>&1 &
-  wait_for_pg
+  start_pg
 }
 
 wait_for_pg() {
   until /etc/init.d/postgresql status; do sleep 0.1; done
+}
+
+stop_pg() {
+  /etc/init.d/postgresql stop || true
+  while /etc/init.d/postgresql status; do sleep 0.1; done
+}
+
+start_pg() {
+  /usr/bin/run-database.sh > /tmp/postgres.log 2>&1 &
+  wait_for_pg
+}
+
+restart_pg() {
+  stop_pg
+  start_pg
 }
 
 install-heartbleeder() {


### PR DESCRIPTION
Adds support for [logical streaming replication for PostgreSQL](https://2ndquadrant.com/en/resources/pglogical/pglogical-docs/)
For request [#8678](https://aptible.zendesk.com/agent/tickets/8678)

To enable, an `ALTER SYSTEM SET` must be called, followed by a database restart for the setting to take effect:

```
ALTER SYSTEM SET shared_preload_libraries='pglogical,'pg_stat_statements';
```

Then, the extension can be loaded via `CREATE EXTENSION pglogical;` For postgres 9.4, the "pglogical_origin" extension also must be loaded.