### PR TITLE
Add pg-safeupdate to *-contrib images

### DIFF
--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.3.17" {
-  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.17"
+@test "It should install PostgreSQL 9.3.19" {
+  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.19"
 }
 
 @test "It should support PLV8" {

--- a/9.3/test/postgresql-9.3.bats
+++ b/9.3/test/postgresql-9.3.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.3.17" {
-  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.17"
+@test "It should install PostgreSQL 9.3.19" {
+  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.19"
 }

--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -34,3 +34,4 @@ pgxn install "plv8==1.4.4"
 pgxn install --testing "pg_proctab==0.0.5"
 USE_PGXS=1 pgxn install "mysql_fdw==2.1.2"
 pgxn install "multicorn==1.3.3"
+pgxn install safeupdate

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -66,3 +66,14 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION pglogical_origin;"
   sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
 }
+
+@test "It should support pg-safeupdate" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='safeupdate';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE TABLE foo (i int);"
+  sudo -u postgres psql --command "INSERT INTO foo VALUES (1234);"
+  run sudo -u postgres psql --command "DELETE FROM foo;"
+  [ "$status" -eq "1" ]
+  [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
+}

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.4.12" {
-  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.12"
+@test "It should install PostgreSQL 9.4.14" {
+  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.14"
 }
 
 @test "It should support PLV8" {

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.4.12" {
-  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.12"
+@test "It should install PostgreSQL 9.4.14" {
+  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.14"
 }

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -33,3 +33,4 @@ pgxn install "tds_fdw==1.0.7"
 pgxn install "plv8==1.4.4"
 USE_PGXS=1 pgxn install "mysql_fdw==2.1.2"
 pgxn install "multicorn==1.3.3"
+pgxn install safeupdate

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -60,3 +60,14 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   restart_pg
   sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
 }
+
+@test "It should support pg-safeupdate" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='safeupdate';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE TABLE foo (i int);"
+  sudo -u postgres psql --command "INSERT INTO foo VALUES (1234);"
+  run sudo -u postgres psql --command "DELETE FROM foo;"
+  [ "$status" -eq "1" ]
+  [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
+}

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.5.7" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.7"
+@test "It should install PostgreSQL 9.5.9" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.9"
 }
 
 @test "It should support PLV8" {

--- a/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
+++ b/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.5.7" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.7"
+@test "It should install PostgreSQL 9.5.9" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.9"
 }
 
 @test "It should support pg_cron" {

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.5.7" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.7"
+@test "It should install PostgreSQL 9.5.9" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.9"
 }

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -30,6 +30,7 @@ pip install pgxnclient
 
 pgxn install "plv8==1.4.4"
 pgxn install "multicorn==1.3.3"
+pgxn install safeupdate
 
 # Install extensions from source (expects tarball URL as argument)
 install_extension_from_source() {

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -55,3 +55,14 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   restart_pg
   sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
 }
+
+@test "It should support pg-safeupdate" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='safeupdate';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE TABLE foo (i int);"
+  sudo -u postgres psql --command "INSERT INTO foo VALUES (1234);"
+  run sudo -u postgres psql --command "DELETE FROM foo;"
+  [ "$status" -eq "1" ]
+  [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
+}

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.6.3" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.3"
+@test "It should install PostgreSQL 9.6.5" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.5"
 }
 
 @test "It should support PLV8" {

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.6.3" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.3"
+@test "It should install PostgreSQL 9.6.5" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.5"
 }


### PR DESCRIPTION
`safeupdate` is a simple extension to PostgreSQL that raises an error if UPDATE and DELETE are executed without specifying conditions. Customer request, ZD ticket 11917.

Execute `ALTER SYSTEM SET shared_preload_libraries='safeupdate';` and reload the database to enable.

https://bitbucket.org/eradman/pg-safeupdate/