### PR TITLE
Add pgaudit to 9.6 and 9.5 contrib images.

### DIFF
--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -10,7 +10,7 @@ apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
 
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
-  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$"
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$"
 
 # Now, install source extensions
 

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -71,3 +71,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   [ "$status" -eq "1" ]
   [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
 }
+
+@test "It should support pgaudit" {
+  dpkg-query -l "postgresql-${PG_VERSION}-pgaudit"
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pgaudit';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pgaudit;"
+}

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -10,7 +10,7 @@ apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
 
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
-  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$"
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$"
 
 # Now, install source extensions
 

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -66,3 +66,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   [ "$status" -eq "1" ]
   [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
 }
+
+@test "It should support pgaudit" {
+  dpkg-query -l "postgresql-${PG_VERSION}-pgaudit"
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pgaudit';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pgaudit;"
+}


### PR DESCRIPTION
`pgaudit` is an extension to PostgreSQL that provides detailed session and/or object audit logging via the standard logging facility. Customer request, ZD ticket 11917.

Execute `ALTER SYSTEM SET shared_preload_libraries='pgaudit';` and reload the database to enable.

https://www.pgaudit.org/