### PR TITLE
Update makefile

### DIFF
--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.1" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.1"
+@test "It should install PostgreSQL 10.3" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.3"
 }
 
 @test "It should support pg_cron" {

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 10.1" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.1"
+@test "It should install PostgreSQL 10.3" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.3"
 }

--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.3.20" {
-  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.20"
+@test "It should install PostgreSQL 9.3.22" {
+  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.22"
 }
 
 @test "It should support PLV8" {

--- a/9.3/test/postgresql-9.3.bats
+++ b/9.3/test/postgresql-9.3.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.3.20" {
-  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.20"
+@test "It should install PostgreSQL 9.3.22" {
+  /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.22"
 }

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.4.15" {
-  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.15"
+@test "It should install PostgreSQL 9.4.17" {
+  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.17"
 }
 
 @test "It should support PLV8" {

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.4.15" {
-  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.15"
+@test "It should install PostgreSQL 9.4.17" {
+  /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.17"
 }

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.5.10" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.10"
+@test "It should install PostgreSQL 9.5.12" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.12"
 }
 
 @test "It should support PLV8" {

--- a/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
+++ b/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.5.10" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.10"
+@test "It should install PostgreSQL 9.5.12" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.12"
 }
 
 @test "It should support pg_cron" {

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.5.10" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.10"
+@test "It should install PostgreSQL 9.5.12" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.12"
 }

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.6.6" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.6"
+@test "It should install PostgreSQL 9.6.8" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.8"
 }
 
 @test "It should support PLV8" {

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.6.6" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.6"
+@test "It should install PostgreSQL 9.6.8" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.8"
 }

--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,5 @@ $(TAG):
 	mkdir -p "$(TAG)"
 
 
-.PHONY: push build
+.PHONY: push test build $(TAG)/Dockerfile
 .DEFAULT_GOAL := test

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -20,6 +20,9 @@ teardown() {
 
   rm -rf "$WORK_DIR"
   unset WORK_DIR
+
+  # Be safe and delete those should a test leave them behind.
+  rm -f "/restore-input" "/dump-output"
 }
 
 initialize_and_start_pg() {


### PR DESCRIPTION
- Drop -f from docker tag, since that flag is deprecated.
- Assume $(TAG)/Dockerfile is always out of date, since it depends on
  `config.mk`, which itself could depend on anything. In practice, we
  don't lose any performance there, since a) regenerating that file is
  cheap and b) build is already phony (but has Docker caching).