### PR TITLE
Add 10-contrib tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - TAG=9.6
     - TAG=9.6-contrib
     - TAG=10
+    - TAG=10-contrib
     - TAG=10-pg_cron
 
 script:

--- a/10-contrib/config.mk
+++ b/10-contrib/config.mk
@@ -1,0 +1,4 @@
+export POSTGRES_VERSION = 10
+export POSTGIS_VERSION = 2.4
+export AUTH_METHOD = peer
+export PRELOAD_LIB = pg_stat_statements

--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+
+# We'll need the pglogical repo...
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+
+# ...and its key
+apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 5D941908AA7A6805
+
+# Install packaged extensions first
+apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
+  "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$"
+
+# Now, install source extensions
+
+DEPS=(
+  build-essential python-pip
+  libpq-dev "^postgresql-server-dev-${PG_VERSION}$"
+  libv8-3.14-dev
+  libmysqlclient-dev
+  python-dev
+)
+
+apt-install "${DEPS[@]}"
+pip install pgxnclient
+
+pgxn install "plv8==1.4.4"
+pgxn install "multicorn==1.3.5"
+pgxn install safeupdate
+
+# Install extensions from source (expects tarball URL as argument)
+install_extension_from_source() {
+  tarball_url=$1
+  shift
+  shasum=$1
+  shift
+
+  pushd .
+  tempdir=$(mktemp -d)
+
+  cd $tempdir
+  wget -O extension.tar.gz $tarball_url
+  echo "${shasum}  extension.tar.gz" | sha1sum -c - || exit
+  mkdir -p extension
+  tar xzf extension.tar.gz -C extension --strip-components 1
+
+  cd extension
+  make USE_PGXS=1 install
+
+  cd $tempdir
+  rm -rf extension extension.tar.gz
+  popd
+}
+
+install_extension_from_source \
+  https://github.com/EnterpriseDB/mysql_fdw/archive/REL-2_3_0.tar.gz \
+  a2dbd00bb4929ecacbf9c21bde762ad5afbe7af7

--- a/10-contrib/test/postgresql-10-contrib.bats
+++ b/10-contrib/test/postgresql-10-contrib.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should install PostgreSQL 10.3" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.3"
+}
+
+@test "It should support PLV8" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION plv8;"
+  sudo -u postgres psql --command "CREATE EXTENSION plls;"
+  sudo -u postgres psql --command "CREATE EXTENSION plcoffee;"
+}
+
+@test "It should support plpythonu" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION plpythonu;"
+}
+
+@test "It should support plpython2u" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION plpython2u;"
+}
+
+@test "It should support plpython3u" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION plpython3u;"
+}
+
+@test "It should support mysql_fdw" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION mysql_fdw;"
+}
+
+@test "It should support multicorn" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION multicorn;"
+}
+
+@test "It should support plperl" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE LANGUAGE plperl;"
+}
+
+@test "It should support plperlu" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE LANGUAGE plperlu;"
+}
+
+@test "It should support pglogical" {
+  dpkg-query -l postgresql-${PG_VERSION}-pglogical
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pglogical';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
+}
+
+@test "It should support pg-safeupdate" {
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='safeupdate';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE TABLE foo (i int);"
+  sudo -u postgres psql --command "INSERT INTO foo VALUES (1234);"
+  run sudo -u postgres psql --command "DELETE FROM foo;"
+  [ "$status" -eq "1" ]
+  [ "${lines[0]}" = "ERROR:  DELETE requires a WHERE clause" ]
+}
+
+@test "It should support pgaudit" {
+  dpkg-query -l "postgresql-${PG_VERSION}-pgaudit"
+  initialize_and_start_pg
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pgaudit';"
+  restart_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pgaudit;"
+}


### PR DESCRIPTION
All extensions supported on 9.6 are also supported here. Only 2 versions have changed from 9.6:

* multicorn is now 1.3.5 instead of 1.3.3 (1.3.4 is the minimum for PG 10)
* mysql_fdw is now 2.3.0 instead of 2.2.0 (2.3.0 is the minimum for PG 10)