### PR TITLE
Configure replication slots on PG 9.5 and up

### DIFF
--- a/test-replication.sh
+++ b/test-replication.sh
@@ -85,4 +85,11 @@ sleep 1
 docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
 docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
 
+# shellcheck disable=SC2016
+if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" gt 9.5'; then
+  # This will return CANARY only if there is > 0 rows in the pg_replication_slots table:
+  docker run -i --rm "$IMG" --client "$MASTER_URL" -c "SELECT 'CANARY' FROM pg_replication_slots;" | grep CANARY
+  echo "Replication slot OK"
+fi
+
 echo "Test OK!"


### PR DESCRIPTION
Using a replication slot ensures the primary will not delete data that
a secondary still needs, preventing secondaries from going out of sync,
and ensuring that queries can complete on secondaries without recovery
conflicts.

---

cc @fancyremarker @UserNotFound - for now, I'm just opening this to run tests on it. there's at least 3 things we need to consider before moving forward with this:

- Leaving replication slots behind when a replica is deleted will cause problems (e.g. running out of disk eventually)
- If a `--initialize-from` operation fails halfway (that is less likely with this PR though!), it'll leave a replication slot behind (causing the same issue).
- We probably want to make sure that restoring from a backup does not reuse the replication slot (or replication in general). I've included this in this PR (see: `--initialize-backup`-.