### PR TITLE
Updating dependencies

### DIFF
--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -25,7 +25,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 pgxn install "plv8==1.4.4"
 pgxn install "multicorn==1.3.5"

--- a/11-contrib/install-extras.sh
+++ b/11-contrib/install-extras.sh
@@ -25,7 +25,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 # PLV8 v2.3.7 required for PG11
 # https://github.com/plv8/plv8/blob/r3.0alpha/Changes#L15-L16

--- a/9.3-contrib/install-extras.sh
+++ b/9.3-contrib/install-extras.sh
@@ -18,7 +18,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 pgxn install "tds_fdw==1.0.7"
 pgxn install "plv8==1.4.4"

--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -25,7 +25,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 pgxn install "tds_fdw==1.0.7"
 pgxn install "plv8==1.4.4"

--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -2,6 +2,25 @@
 set -o errexit
 set -o nounset
 
+# pg_repack linked against libpq5 11 breaks with libpq5 12
+# https://www.postgresql.org/message-id/flat/20191007065916.GH14532%40paquier.xyz#f9902a2c15d0448bf95c4eac15ec86b3
+# 11 worked so let's use that. We can get the older version by adding the "11" archive our source list:
+# https://wiki.postgresql.org/wiki/Apt/FAQ#I_want_libpq5_for_version_X.2C_but_there_is_only_version_Y_in_the_repository
+
+sed -i '$ s/$/ 11/' /etc/apt/sources.list.d/pgdg.list
+
+cat > /etc/apt/preferences.d/libpq << EOL
+Package: libpq5
+Pin: version 11.*
+Pin-Priority: 1000
+
+Package: libpq-dev
+Pin: version 11.*
+Pin-Priority: 1000
+EOL
+
+apt-install --force-yes "libpq5"
+
 # We'll need the pglogical repo...
 echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
 

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -16,3 +16,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION pg_proctab;"
 }
 
+@test "The libpq version should be pinned for for pg_repack" {
+  dpkg-query -l libpq-dev | grep -F "11."
+  dpkg-query -l libpq5 | grep -F "11."
+}

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -25,7 +25,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 pgxn install "tds_fdw==1.0.7"
 pgxn install "plv8==1.4.4"

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -24,7 +24,7 @@ DEPS=(
 )
 
 apt-install "${DEPS[@]}"
-pip install pgxnclient
+pip install 'pgxnclient<1.3'
 
 pgxn install "plv8==1.4.4"
 pgxn install "multicorn==1.3.3"

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -52,7 +52,7 @@ RUN apt-key add /tmp/GPGkeys/postgresql-debian.key \
  && apt-get update \
  && apt-get -y install postgresql-common \
  && sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
- && apt-get -y install \
+ && apt-get -y install python \
     "^postgresql-${PG_VERSION}\$" \
     "^postgresql-client-${PG_VERSION}\$" \
     "^postgresql-contrib-${PG_VERSION}\$" \


### PR DESCRIPTION
Python decided not to resolve as a required dependency anymore, so we need to explicitly include it (for autotune).

Resolves this build error : https://travis-ci.org/aptible/docker-postgresql/builds/592120289