### PR TITLE
Support replication slots for PG 9.6 and up.

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -122,7 +122,9 @@ elif [[ "$1" == "--initialize-from" ]]; then
     -d "$protocol$REPL_USER:$REPL_PASS@$host_and_port/$database?ssl=true"
   )
 
-  if dpkg --compare-versions "$PG_VERSION" ge '9.5'; then
+  # Allow for optional bypassing of replication slots to support
+  # legacy replicas.
+  if [[ -z "${NO_SLOTS}" ]] && dpkg --compare-versions "$PG_VERSION" ge '9.6'; then
     REPL_SLOT="$(pwgen -s 20 | tr '[:upper:]' '[:lower:]')_$(date +%s)"
     psql "$2" --command "SELECT * FROM pg_create_physical_replication_slot('$REPL_SLOT');" > /dev/null
 

--- a/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
+++ b/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
@@ -39,6 +39,7 @@ wal_level = hot_standby
 max_wal_senders = 3
 wal_keep_segments = 8
 hot_standby = on
+max_replication_slots = 10 # __NOT_IF_PG_9.5__  __NOT_IF_PG_9.4__ __NOT_IF_PG_9.3__
 
 # Checkpointing configuration is required on PG < 9.5. However, 9.5 has smarter
 # defaults, so we don't have it there.

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -85,4 +85,11 @@ sleep 1
 docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
 docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
 
+# shellcheck disable=SC2016
+if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" gt 9.5'; then
+  # This will return CANARY only if there is > 0 rows in the pg_replication_slots table:
+  docker run -i --rm "$IMG" --client "$MASTER_URL" -c "SELECT 'CANARY' FROM pg_replication_slots;" | grep CANARY
+  echo "Replication slot OK"
+fi
+
 echo "Test OK!"


### PR DESCRIPTION
This adds replication for 9.6 and above. Replication slots were introduced in 9.4, but 9.6 is the first version that allows you to specify a replication slot when using `pg_basebackup`. 

I did make one semi-controversial decision here (at the suggestion of @UserNotFound): I added the option to re-initialize the replica without utilizing slots by including a `NO_SLOTS` environment variable. The thought process here is that we may have a "legacy" replica that needs re-init'd, and we're not in a position where the primary can be restarted. I'm not sure how I feel about supporting this use case (although I do get it), but it is pretty trivial to support, so I accounted for it. 

