### PR TITLE
Increase max_wal_senders to the current PG default.

### DIFF
--- a/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
+++ b/templates/etc/postgresql/PG_VERSION/main/postgresql.conf.template
@@ -36,7 +36,7 @@ shared_buffers = 128MB
 #------------------------------------------------------------------------------
 
 wal_level = hot_standby
-max_wal_senders = 3
+max_wal_senders = 10
 wal_keep_segments = 8
 hot_standby = on
 max_replication_slots = 10 # __NOT_IF_PG_9.5__  __NOT_IF_PG_9.4__ __NOT_IF_PG_9.3__


### PR DESCRIPTION
The default here was 0 for all PG versions prior to 10, so our choice of 3 seemed reasonable.  PostgreSQL default is 10, so it should not be risky to increase for our use case.

https://www.postgresql.org/docs/10/runtime-config-replication.html

This should help avoid errors when creating a third replica.