### PR TITLE
Add pgAgent extension

### DIFF
--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -12,7 +12,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" \
   "^postgresql-${PG_VERSION}-pgaudit$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-repack"
+  "^postgresql-${PG_VERSION}-repack" "^pgagent$"
 
 # Now, install source extensions
 

--- a/11-contrib/install-extras.sh
+++ b/11-contrib/install-extras.sh
@@ -12,7 +12,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" \
   "^postgresql-${PG_VERSION}-pgaudit$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-repack"
+  "^postgresql-${PG_VERSION}-repack" "^pgagent$"
 
 # Now, install source extensions
 

--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -30,7 +30,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-repack"
+  "^postgresql-${PG_VERSION}-repack" "^pgagent$"
 
 # Now, install source extensions
 

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -11,7 +11,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$" \
-  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack"
+  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$"
 
 # Now, install source extensions
 

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -11,7 +11,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$" \
-  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack"
+  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$"
 
 # Now, install source extensions
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,31 @@ The PostgreSQL server is configured to enforce SSL for any TCP connection. It us
 * `9.4`: PostgreSQL 9.4 (EOL 2020-02-13)
 * `9.3`: PostgreSQL 9.3 (EOL 2018-11-08)
 
+## Available Extensions
+
+In the `--contrib` images, the following extensions are available.
+
+| Extension | Avaiable in versions|
+|-----------|---------------------|
+| plpythonu | 9.3 - 11 |
+| plpython2u | 9.3 - 11 |
+| plpython3u | 9.3 - 11 |
+| plperl | 9.3 - 11 |
+| plperlu | 9.3 - 11 |
+| mysql_fdw | 9.3 - 11 |
+| PLV8 |  9.3 - 11|
+| multicorn | 9.3 - 10 |
+| wal2json |  9.4 - 11 |
+| pg-safeupdate | 9.4 - 11 |
+| pglogical | 9.4 - 11 |
+| pg_repack | 9.4 - 11 |
+| pgagent | 9.4 - 11 |
+| pggent|  9.4 - 11 |
+| pgaudit |  9.5 - 11 |
+| pgcron | 10 |
+
+Aptible Support can update your Database to use the `--contrib` image.
+
 ## Tests
 
 Tests are run as part of the `Dockerfile` build. To execute them separately within a container, run:

--- a/test/postgresql-contrib.bats
+++ b/test/postgresql-contrib.bats
@@ -143,3 +143,11 @@ versions-only() {
   sudo -u postgres psql --command "CREATE EXTENSION pg_repack;"
   sudo -u postgres pg_repack --dry-run
 }
+
+@test "It should support pgagent" {
+  contrib-only
+  versions-only ge 9.4
+
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION pgagent;"
+}


### PR DESCRIPTION
Not only is pgAgent required to be configured as an extension, but it requires you to run the pgagent service, as well. Rather than adding process management into our Database image, this should be deployed an run as an App.  This can be done with minimal work, using the `--contrib` image as a base, since the package is already installed there, and we can take advantage of `parase_url` in our image to parse a database URL into the options passed to `pgagent`:

```
FROM aptible/postgresql:11-contrib
ADD entrypoint.sh /
ENTRYPOINT ["/bin/bash", "-c"]

# You need to provide your Database connection URL as "DB:URL":
# eg `aptible config:set --app $HANDLE DB_URL="postgresql://aptible:...."`

CMD ["/entrypoint.sh"]
```


```
#!/bin/sh
set -o nounset

. /usr/bin/utilities.sh
parse_url "$DB_URL"

exec pgagent host=${host} port=${port} user=${user}  password=${password} dbname=${database} -f -l 1
```