### PR TITLE
Update PostgreSQL where possible. Ensure PostGIS version compatibility.

### DIFF
--- a/10-contrib/config.mk
+++ b/10-contrib/config.mk
@@ -1,1 +1,5 @@
-../10/config.mk
+export DEBIAN_VERSION = jessie
+export POSTGRES_VERSION = 10
+export POSTGIS_VERSION = 2.4
+export AUTH_METHOD = peer
+export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/10-contrib/test/postgresql-10-contrib.bats
+++ b/10-contrib/test/postgresql-10-contrib.bats
@@ -1,11 +1,18 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 10.13" {
   /usr/lib/postgresql/10/bin/postgres --version | grep "10.13"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {
-  run dpkg --status  postgresql-10-postgis-2.4
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/10-contrib/test/postgresql-10-contrib.bats
+++ b/10-contrib/test/postgresql-10-contrib.bats
@@ -4,3 +4,8 @@
   /usr/lib/postgresql/10/bin/postgres --version | grep "10.13"
 }
 
+@test "This image needs to forever support PostGIS 2.4" {
+  run dpkg --status  postgresql-10-postgis-2.4
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/10-pg_cron/config.mk
+++ b/10-pg_cron/config.mk
@@ -1,6 +1,6 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 10
-export POSTGIS_VERSION = "2.4 3"
+export POSTGIS_VERSION = "2.4"
 export AUTH_METHOD = trust
 export PRELOAD_LIB = "pg_stat_statements,pg_cron,pglogical"
 export PG_CRON_VERSION=1.0.2

--- a/10-pg_cron/config.mk
+++ b/10-pg_cron/config.mk
@@ -1,6 +1,6 @@
-export DEBIAN_VERSION = jessie
+export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 10
-export POSTGIS_VERSION = 2.4
+export POSTGIS_VERSION = "2.4 3"
 export AUTH_METHOD = trust
 export PRELOAD_LIB = "pg_stat_statements,pg_cron,pglogical"
 export PG_CRON_VERSION=1.0.2

--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.13" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.13"
+@test "It should install PostgreSQL 10.14" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.14"
 }
 
 @test "It should support pg_cron" {
@@ -12,7 +12,23 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {
-  run dpkg --status  postgresql-10-postgis-2.4
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -23,7 +23,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -10,3 +10,9 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE EXTENSION pg_cron;"
 }
+
+@test "This image needs to forever support PostGIS 2.4" {
+  run dpkg --status  postgresql-10-postgis-2.4
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/10/config.mk
+++ b/10/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 10
-export POSTGIS_VERSION = "2.4 3"
+export POSTGIS_VERSION = "2.4"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/10/config.mk
+++ b/10/config.mk
@@ -1,5 +1,5 @@
-export DEBIAN_VERSION = jessie
+export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 10
-export POSTGIS_VERSION = 2.4
+export POSTGIS_VERSION = "2.4 3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 10.13" {
   /usr/lib/postgresql/10/bin/postgres --version | grep "10.13"
 }
+
+@test "This image needs to forever support PostGIS 2.4" {
+  run dpkg --status  postgresql-10-postgis-2.4
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 10.13" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.13"
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should install PostgreSQL 10.14" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.14"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {
-  run dpkg --status  postgresql-10-postgis-2.4
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 11.9" {
   /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }
+
+@test "This image needs to forever support PostGIS 2.5" {
+  run dpkg --status  postgresql-11-postgis-2.5
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 11.8" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.8"
+@test "It should install PostgreSQL 11.9" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 11.9" {
   /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {
-  run dpkg --status  postgresql-11-postgis-2.5
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.5"
+
+  full=$(get_full_postgis_version "2.5")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/11/config.mk
+++ b/11/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 11
-export POSTGIS_VERSION = 2.5
+export POSTGIS_VERSION = "2.5 3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/11/config.mk
+++ b/11/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 11
-export POSTGIS_VERSION = "2.5 3"
+export POSTGIS_VERSION = "2.5"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 11.9" {
   /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }
+
+@test "This image needs to forever support PostGIS 2.5" {
+  run dpkg --status  postgresql-11-postgis-2.5
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 11.8" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.8"
+@test "It should install PostgreSQL 11.9" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 11.9" {
   /usr/lib/postgresql/11/bin/postgres --version | grep "11.9"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {
-  run dpkg --status  postgresql-11-postgis-2.5
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.5"
+
+  full=$(get_full_postgis_version "2.5")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 12.3" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.3"
+@test "It should install PostgreSQL 12.4" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 12.4" {
   /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {
-  run dpkg --status  postgresql-12-postgis-2.5
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.5"
+
+  full=$(get_full_postgis_version "2.5")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 12.4" {
   /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }
+
+@test "This image needs to forever support PostGIS 2.5" {
+  run dpkg --status  postgresql-12-postgis-2.5
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/12/config.mk
+++ b/12/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 12
-export POSTGIS_VERSION = "2.5 3"
+export POSTGIS_VERSION = "2.5"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/12/config.mk
+++ b/12/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 12
-export POSTGIS_VERSION = 2.5
+export POSTGIS_VERSION = "2.5 3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 12.3" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.3"
+@test "It should install PostgreSQL 12.4" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 12.4" {
   /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {
-  run dpkg --status  postgresql-12-postgis-2.5
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.5"
+
+  full=$(get_full_postgis_version "2.5")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 12.4" {
   /usr/lib/postgresql/12/bin/postgres --version | grep "12.4"
 }
+
+@test "This image needs to forever support PostGIS 2.5" {
+  run dpkg --status  postgresql-12-postgis-2.5
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -16,13 +16,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION pg_proctab;"
 }
 
-@test "This image needs to forever support PostGIS 2.1" {
-
-  check_postgis "2.1"
-
-  full=$(get_full_postgis_version "2.1")
+@test "It should support some version of PostGIS" {
+  # The versioning of the packages that gets installed is all messed up,
+  # but this version is deprecated so there's no need to make changes.
 
   initialize_and_start_pg
-  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis;\""
   [ "$status" -eq "0" ]
 }

--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -15,3 +15,9 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE EXTENSION pg_proctab;"
 }
+
+@test "This image needs to forever support PostGIS 2.1" {
+  run dpkg --status  postgresql-9.3-postgis-2.1
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.3-contrib/test/postgresql-9.3-contrib.bats
+++ b/9.3-contrib/test/postgresql-9.3-contrib.bats
@@ -17,7 +17,12 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "This image needs to forever support PostGIS 2.1" {
-  run dpkg --status  postgresql-9.3-postgis-2.1
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.1"
+
+  full=$(get_full_postgis_version "2.1")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.3/test/postgresql-9.3.bats
+++ b/9.3/test/postgresql-9.3.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 9.3.25" {
   /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.25"
 }
+
+@test "This image needs to forever support PostGIS 2.1" {
+  run dpkg --status  postgresql-9.3-postgis-2.1
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.3/test/postgresql-9.3.bats
+++ b/9.3/test/postgresql-9.3.bats
@@ -5,7 +5,12 @@
 }
 
 @test "This image needs to forever support PostGIS 2.1" {
-  run dpkg --status  postgresql-9.3-postgis-2.1
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.1"
+
+  full=$(get_full_postgis_version "2.1")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.3/test/postgresql-9.3.bats
+++ b/9.3/test/postgresql-9.3.bats
@@ -1,16 +1,17 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+
 @test "It should install PostgreSQL 9.3.25" {
   /usr/lib/postgresql/9.3/bin/postgres --version | grep "9.3.25"
 }
 
-@test "This image needs to forever support PostGIS 2.1" {
-
-  check_postgis "2.1"
-
-  full=$(get_full_postgis_version "2.1")
+@test "It should support some version of PostGIS" {
+  # The versioning of the packages that gets installed is all messed up,
+  # but this version is deprecated so there's no need to make changes.
 
   initialize_and_start_pg
-  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis;\""
   [ "$status" -eq "0" ]
 }

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -20,3 +20,9 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   dpkg-query -l libpq-dev | grep -F "11."
   dpkg-query -l libpq5 | grep -F "11."
 }
+
+@test "This image needs to forever support PostGIS 2.1" {
+  run dpkg --status  postgresql-9.4-postgis-2.1
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -22,7 +22,12 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "This image needs to forever support PostGIS 2.1" {
-  run dpkg --status  postgresql-9.4-postgis-2.1
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.1"
+
+  full=$(get_full_postgis_version "2.1")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.4-contrib/test/postgresql-9.4-contrib.bats
+++ b/9.4-contrib/test/postgresql-9.4-contrib.bats
@@ -21,13 +21,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   dpkg-query -l libpq5 | grep -F "11."
 }
 
-@test "This image needs to forever support PostGIS 2.1" {
-
-  check_postgis "2.1"
-
-  full=$(get_full_postgis_version "2.1")
+@test "It should support some version of PostGIS" {
+  # The versioning of the packages that gets installed is all messed up,
+  # but this version is deprecated so there's no need to make changes.
 
   initialize_and_start_pg
-  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis;\""
   [ "$status" -eq "0" ]
 }

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 9.4.26" {
   /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.26"
 }
+
+@test "This image needs to forever support PostGIS 2.1" {
+  run dpkg --status  postgresql-9.4-postgis-2.1
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -5,7 +5,12 @@
 }
 
 @test "This image needs to forever support PostGIS 2.1" {
-  run dpkg --status  postgresql-9.4-postgis-2.1
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.1"
+
+  full=$(get_full_postgis_version "2.1")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.4/test/postgresql-9.4.bats
+++ b/9.4/test/postgresql-9.4.bats
@@ -1,16 +1,16 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 9.4.26" {
   /usr/lib/postgresql/9.4/bin/postgres --version | grep "9.4.26"
 }
 
-@test "This image needs to forever support PostGIS 2.1" {
-
-  check_postgis "2.1"
-
-  full=$(get_full_postgis_version "2.1")
+@test "It should support some version of PostGIS" {
+  # The versioning of the packages that gets installed is all messed up,
+  # but this version is deprecated so there's no need to make changes.
 
   initialize_and_start_pg
-  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis;\""
   [ "$status" -eq "0" ]
 }

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -11,11 +11,19 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION tds_fdw;"
 }
 
-@test "This image needs to forever support PostGIS 2.2" {
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.2
+}
 
-  check_postgis "2.2"
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.3
+}
 
-  full=$(get_full_postgis_version "2.2")
+@test "This image should support installing PostGIS 2.4" {
+
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
 
   initialize_and_start_pg
   run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -12,7 +12,12 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "This image needs to forever support PostGIS 2.2" {
-  run dpkg --status  postgresql-9.5-postgis-2.2
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.2"
+
+  full=$(get_full_postgis_version "2.2")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -11,4 +11,8 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION tds_fdw;"
 }
 
+@test "This image needs to forever support PostGIS 2.2" {
+  run dpkg --status  postgresql-9.5-postgis-2.2
 
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.5-contrib/test/postgresql-9.5-contrib.bats
+++ b/9.5-contrib/test/postgresql-9.5-contrib.bats
@@ -15,7 +15,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   check_postgis_library 2.2
 }
 
-@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+@test "This image needs to forever support PostGIS 2.3 where it is already installed" {
   check_postgis_library 2.3
 }
 

--- a/9.5-pg_cron/config.mk
+++ b/9.5-pg_cron/config.mk
@@ -1,6 +1,6 @@
 export DEBIAN_VERSION = jessie
 export POSTGRES_VERSION = 9.5
-export POSTGIS_VERSION = 2.2
+export POSTGIS_VERSION = "2.2 2.3 2.4"
 export AUTH_METHOD = trust
 export PRELOAD_LIB = "pg_stat_statements,pg_cron,pglogical"
 export PG_CRON_VERSION=1.0.2

--- a/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
+++ b/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
@@ -11,11 +11,19 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   sudo -u postgres psql --command "CREATE EXTENSION pg_cron;"
 }
 
-@test "This image needs to forever support PostGIS 2.2" {
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.2
+}
 
-  check_postgis "2.2"
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.3
+}
 
-  full=$(get_full_postgis_version "2.2")
+@test "This image should support installing PostGIS 2.4" {
+
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
 
   initialize_and_start_pg
   run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""

--- a/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
+++ b/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
@@ -10,3 +10,9 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE EXTENSION pg_cron;"
 }
+
+@test "This image needs to forever support PostGIS 2.2" {
+  run dpkg --status  postgresql-9.5-postgis-2.2
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
+++ b/9.5-pg_cron/test/postgresql-9.5-pg_cron.bats
@@ -12,7 +12,12 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "This image needs to forever support PostGIS 2.2" {
-  run dpkg --status  postgresql-9.5-postgis-2.2
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.2"
+
+  full=$(get_full_postgis_version "2.2")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.5/config.mk
+++ b/9.5/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = jessie
 export POSTGRES_VERSION = 9.5
-export POSTGIS_VERSION = "2.2 2.3 2.4"
+export POSTGIS_VERSION = 2.2
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.5/config.mk
+++ b/9.5/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = jessie
 export POSTGRES_VERSION = 9.5
-export POSTGIS_VERSION = 2.2
+export POSTGIS_VERSION = "2.2 2.3 2.4"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 9.5.22" {
   /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.22"
 }
+
+@test "This image needs to forever support PostGIS 2.2" {
+  run dpkg --status  postgresql-9.5-postgis-2.2
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -6,11 +6,19 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
   /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.22"
 }
 
-@test "This image needs to forever support PostGIS 2.2" {
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.2
+}
 
-  check_postgis "2.2"
+@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+  check_postgis_library 2.3
+}
 
-  full=$(get_full_postgis_version "2.2")
+@test "This image should support installing PostGIS 2.4" {
+
+  check_postgis "2.4"
+
+  full=$(get_full_postgis_version "2.4")
 
   initialize_and_start_pg
   run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -1,11 +1,18 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 9.5.22" {
   /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.22"
 }
 
 @test "This image needs to forever support PostGIS 2.2" {
-  run dpkg --status  postgresql-9.5-postgis-2.2
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.2"
+
+  full=$(get_full_postgis_version "2.2")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.6-contrib/config.mk
+++ b/9.6-contrib/config.mk
@@ -1,1 +1,5 @@
-../9.6/config.mk
+export DEBIAN_VERSION = jessie
+export POSTGRES_VERSION = 9.6
+export POSTGIS_VERSION = 2.3
+export AUTH_METHOD = peer
+export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -4,3 +4,8 @@
   /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.18"
 }
 
+@test "This image needs to forever support PostGIS 2.3" {
+  run dpkg --status  postgresql-9.6-postgis-2.3
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -1,11 +1,18 @@
 #!/usr/bin/env bats
 
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
 @test "It should install PostgreSQL 9.6.18" {
   /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.18"
 }
 
 @test "This image needs to forever support PostGIS 2.3" {
-  run dpkg --status  postgresql-9.6-postgis-2.3
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.3"
+
+  full=$(get_full_postgis_version "2.3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.6/config.mk
+++ b/9.6/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = jessie
 export POSTGRES_VERSION = 9.6
-export POSTGIS_VERSION = 2.3
+export POSTGIS_VERSION = "2.3 2.4 2.5"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.6/config.mk
+++ b/9.6/config.mk
@@ -1,5 +1,5 @@
-export DEBIAN_VERSION = jessie
+export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 9.6
-export POSTGIS_VERSION = "2.3 2.4 2.5"
+export POSTGIS_VERSION = "2.3 3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.6/config.mk
+++ b/9.6/config.mk
@@ -1,5 +1,5 @@
 export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 9.6
-export POSTGIS_VERSION = "2.3 3"
+export POSTGIS_VERSION = "2.3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -1,11 +1,29 @@
 #!/usr/bin/env bats
 
-@test "It should install PostgreSQL 9.6.18" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.18"
+source "${BATS_TEST_DIRNAME}/test_helper.sh"
+
+@test "It should install PostgreSQL 9.6.19" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.19"
 }
 
 @test "This image needs to forever support PostGIS 2.3" {
-  run dpkg --status  postgresql-9.6-postgis-2.3
 
-  [[ "$output" =~ "Status: install ok installed" ]]
+  check_postgis "2.3"
+
+  full=$(get_full_postgis_version "2.3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "It also supports PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
 }

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -18,7 +18,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.sh"
 }
 
 @test "It also supports PostGIS 3" {
-
+  skip
   check_postgis "3"
 
   full=$(get_full_postgis_version "3")

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -3,3 +3,9 @@
 @test "It should install PostgreSQL 9.6.18" {
   /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.18"
 }
+
+@test "This image needs to forever support PostGIS 2.3" {
+  run dpkg --status  postgresql-9.6-postgis-2.3
+
+  [[ "$output" =~ "Status: install ok installed" ]]
+}

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -23,7 +23,6 @@ RUN set -x \
 
 # Define PostgreSQL version for shared scripts
 ENV PG_VERSION <%= ENV.fetch 'POSTGRES_VERSION' %>
-ENV POSTGIS_VERSION <%= ENV.fetch 'POSTGIS_VERSION' %>
 
 # Temporary workaround for host-container user conflicts on Linux Kernel >= 3.15
 # See https://github.com/docker/docker/issues/6345 for details.
@@ -56,8 +55,14 @@ RUN apt-key add /tmp/GPGkeys/postgresql-debian.key \
     "^postgresql-${PG_VERSION}\$" \
     "^postgresql-client-${PG_VERSION}\$" \
     "^postgresql-contrib-${PG_VERSION}\$" \
-    "^postgresql-${PG_VERSION}-postgis-${POSTGIS_VERSION}\$" \
  && rm -rf /var/lib/apt/lists/*
+
+
+ENV POSTGIS_VERSION <%= ENV.fetch 'POSTGIS_VERSION' %>
+RUN apt-get update \
+ && for v in ${POSTGIS_VERSION}; \
+    do sudo apt-get install -y "^postgresql-${PG_VERSION}-postgis-${v}\$" || true; \
+    done
 
 # Export configuration
 ENV AUTH_METHOD <%= ENV.fetch 'AUTH_METHOD' %>

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -71,3 +71,10 @@ install-heartbleeder() {
 uninstall-heartbleeder() {
   rm -rf heartbleeder.zip heartbleeder
 }
+
+get_full_postgis_version()
+{
+  major=$1
+
+  dpkg-query --showformat='${Version}' --show "postgresql-${PG_VERSION}-postgis-${major}" | awk -F '+' '{print $1}'
+}

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -89,7 +89,7 @@ check_postgis() {
 check_postgis_library() {
   major=$1
 
-  # Ensure the library is available to support already-installed PostGIS
+  # Ensure the library is available to support already-installed version of PostGIS
   [[ -f /usr/lib/postgresql/${PG_VERSION}/lib/postgis-${major}.so ]]
 }
 

--- a/test/test_helper.sh
+++ b/test/test_helper.sh
@@ -78,3 +78,26 @@ get_full_postgis_version()
 
   dpkg-query --showformat='${Version}' --show "postgresql-${PG_VERSION}-postgis-${major}" | awk -F '+' '{print $1}'
 }
+
+check_postgis() {
+  major=$1
+
+  check_postgis_library $major
+  check_postgis_scripts $major
+}
+
+check_postgis_library() {
+  major=$1
+
+  # Ensure the library is available to support already-installed PostGIS
+  [[ -f /usr/lib/postgresql/${PG_VERSION}/lib/postgis-${major}.so ]]
+}
+
+
+check_postgis_scripts() {
+  major=$1
+
+  # Ensure the scripts are available to install this version of PostGIS
+  dpkg --status  postgresql-${PG_VERSION}-postgis-${major}-scripts | grep "Status: install ok installed"
+}
+


### PR DESCRIPTION
Postgis is made primarily of two packages, `postgresql-$PG_VERSION-postgis-$VERSION` and `postgresql-$PG_VERSION-postgis-$VERSION-scripts`.  The "scripts" package provides the installation scripts needed to run `CREATE EXTENSION postgis;`. Once installed, you don't actually need these scripts anymore.

Once the extension is installed in the database, all you need is the library file (.so) at runtime, which is provided by the other package. So, I added test functions `check_postgis_library` and `check_postgis_scripts` to check "is this version of PostGIS supported" and "can you install this version of PostGIS", respectively.

The distinction here is important so that we can:

* ensure aptible/postgresql:9.5 _always_ supports a version of PostGIS we've allowed someone to install at some time in the past (eg, 2.2)
* install additional versions so that customer can upgrade away from PostGIS 2.2

This is necessary because:

* Postgres has a security update to 9.5 (and will have more to come for a few years)
* They dropped support for those new updates in Jessie
* By moving to Stretch, we cannot provide the PostGIS 2.2 library anymore (it's not supported in Stretch)

So, we'll need to follow a multi-stage process to get customers updated

1) Push this image change to 9.5, which still supports PostGIS 2.2, but also up to 2.4
2) Tell customers they need to update PostGIS in their 9.5 databases if they're using it, and it's not already on 2.3 or 2.4
3) Later, at a deadline or once we're sure they have, we can update the image to stretch, dropping PostGIS 2.2

_______

Specific change notes

Tags: 12, 12-contrib, 11 & 11-contrib,
* update to latest version of PG

Tags 10, 10-pg_cron, and 9.6
* updated to latest version of PG
* also updated to stretch

Tag 9.5
* added PostGIS 2.4 support while keeping support for existing versions

Tags 9.4 and 9.3 no changes

_____

Follow up items.

This leaves a couple of things to figure out though. Specifically, the 10-contrib and 9.6-contrib _are not_ updated to the last PG version. This is because to do so requires switching to Stretch, which breaks building the specific version of plv8 we currently provide in those.  I'd prefer to drop that extension, if we can determine it's not in use (we have never provided, or been asked to provide it, in PG 11 and PG 12). However, I'm happy to pair to see if someone else can solve this with me in another PR, since I'm just spinning my wheels on it.

Once  we validated that the changes to support multiple versions of PostGIS in a single database version work as expected, we can also add PostGIS 3.0 support to most, if not all images. I included the tests for this, but "skip"ed them for now, until we actually add that version to config.mk