### PR TITLE
Update PG 9.5, drop PostGIS 2.2

### DIFF
--- a/9.5-contrib/config.mk
+++ b/9.5-contrib/config.mk
@@ -1,1 +1,5 @@
-../9.5/config.mk
+export DEBIAN_VERSION = jessie
+export POSTGRES_VERSION = 9.5
+export POSTGIS_VERSION = "2.2 2.3 2.4"
+export AUTH_METHOD = peer
+export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.5/config.mk
+++ b/9.5/config.mk
@@ -1,5 +1,5 @@
-export DEBIAN_VERSION = jessie
+export DEBIAN_VERSION = stretch
 export POSTGRES_VERSION = 9.5
-export POSTGIS_VERSION = "2.2 2.3 2.4"
+export POSTGIS_VERSION = "2.3 2.4 2.5 3"
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"

--- a/9.5/test/postgresql-9.5.bats
+++ b/9.5/test/postgresql-9.5.bats
@@ -2,23 +2,42 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.5.22" {
-  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.22"
+@test "It should install PostgreSQL 9.5.23" {
+  /usr/lib/postgresql/9.5/bin/postgres --version | grep "9.5.23"
 }
 
-@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
-  check_postgis_library 2.2
-}
-
-@test "This image needs to forever support PostGIS 2.2 where it is already installed" {
+@test "This image needs to forever support PostGIS 2.3 where it is already installed" {
   check_postgis_library 2.3
 }
 
-@test "This image should support installing PostGIS 2.4" {
+@test "This image needs to forever support PostGIS 2.4 where it is already installed" {
+  check_postgis_library 2.4
+}
 
-  check_postgis "2.4"
+@test "This image needs to forever support PostGIS 2.5 where it is already installed" {
+  check_postgis_library 2.5
+}
 
-  full=$(get_full_postgis_version "2.4")
+@test "This image needs to forever support PostGIS 2.5 where it is already installed" {
+  check_postgis_library 3
+}
+
+@test "This image should support installing PostGIS 2.5" {
+
+  check_postgis "2.5"
+
+  full=$(get_full_postgis_version "2.5")
+
+  initialize_and_start_pg
+  run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""
+  [ "$status" -eq "0" ]
+}
+
+@test "This image should support installing PostGIS 3" {
+
+  check_postgis "3"
+
+  full=$(get_full_postgis_version "3")
 
   initialize_and_start_pg
   run su postgres -c "psql --command \"CREATE EXTENSION postgis VERSION '${full}';\""


### PR DESCRIPTION
This requires essentially a breaking change of removing PostGIS 2.2 support.
Customer action will be required before we can release this change.


Still to follow, upgrades to the -contrib images, to deal with PLV8 issues.