### PR TITLE
Update PLV8 support

### DIFF
--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -62,3 +62,7 @@ install_extension_from_source \
 install_extension_from_source \
   https://github.com/pgpartman/pg_partman/archive/v4.3.1.tar.gz \
   22eb8069800614a4601a4ce76519a3d9a41c3311
+
+install_extension_from_source \
+  https://github.com/plv8/plv8/archive/v1.4.10.tar.gz \
+  d9dc4ec137424ce5adbb4c4b02d5509b8e2f574d

--- a/9.3-contrib/install-extras.sh
+++ b/9.3-contrib/install-extras.sh
@@ -25,3 +25,31 @@ pgxn install "plv8==1.4.4"
 pgxn install --testing "pg_proctab==0.0.5"
 USE_PGXS=1 pgxn install "mysql_fdw==2.1.2"
 PYTHON_OVERRIDE=python pgxn install "multicorn==1.3.3"
+
+# Install extensions from source (expects tarball URL as argument)
+install_extension_from_source() {
+  tarball_url=$1
+  shift
+  shasum=$1
+  shift
+
+  pushd .
+  tempdir=$(mktemp -d)
+
+  cd $tempdir
+  wget -O extension.tar.gz $tarball_url
+  echo "${shasum}  extension.tar.gz" | sha1sum -c - || exit
+  mkdir -p extension
+  tar xzf extension.tar.gz -C extension --strip-components 1
+
+  cd extension
+  make USE_PGXS=1 install
+
+  cd $tempdir
+  rm -rf extension extension.tar.gz
+  popd
+}
+
+install_extension_from_source \
+  https://github.com/plv8/plv8/archive/v1.4.10.tar.gz \
+  d9dc4ec137424ce5adbb4c4b02d5509b8e2f574d

--- a/9.4-contrib/install-extras.sh
+++ b/9.4-contrib/install-extras.sh
@@ -52,3 +52,31 @@ pgxn install --testing "pg_proctab==0.0.5"
 USE_PGXS=1 pgxn install "mysql_fdw==2.1.2"
 PYTHON_OVERRIDE=python pgxn install "multicorn==1.3.3"
 pgxn install safeupdate
+
+# Install extensions from source (expects tarball URL as argument)
+install_extension_from_source() {
+  tarball_url=$1
+  shift
+  shasum=$1
+  shift
+
+  pushd .
+  tempdir=$(mktemp -d)
+
+  cd $tempdir
+  wget -O extension.tar.gz $tarball_url
+  echo "${shasum}  extension.tar.gz" | sha1sum -c - || exit
+  mkdir -p extension
+  tar xzf extension.tar.gz -C extension --strip-components 1
+
+  cd extension
+  make USE_PGXS=1 install
+
+  cd $tempdir
+  rm -rf extension extension.tar.gz
+  popd
+}
+
+install_extension_from_source \
+  https://github.com/plv8/plv8/archive/v1.4.10.tar.gz \
+  d9dc4ec137424ce5adbb4c4b02d5509b8e2f574d

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -60,3 +60,7 @@ install_extension_from_source() {
 install_extension_from_source \
   https://github.com/pgpartman/pg_partman/archive/v4.3.1.tar.gz \
   22eb8069800614a4601a4ce76519a3d9a41c3311
+
+install_extension_from_source \
+  https://github.com/plv8/plv8/archive/v1.4.10.tar.gz \
+  d9dc4ec137424ce5adbb4c4b02d5509b8e2f574d

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -61,3 +61,7 @@ install_extension_from_source \
 install_extension_from_source \
   https://github.com/pgpartman/pg_partman/archive/v4.3.1.tar.gz \
   22eb8069800614a4601a4ce76519a3d9a41c3311
+
+install_extension_from_source \
+  https://github.com/plv8/plv8/archive/v1.4.10.tar.gz \
+  d9dc4ec137424ce5adbb4c4b02d5509b8e2f574d

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In the `--contrib` images, the following extensions are available.
 | plperl | 9.3 - 12 |
 | plperlu | 9.3 - 12 |
 | mysql_fdw | 9.3 - 11 |
-| PLV8 |  9.3 - 11|
+| PLV8 |  9.3 - 10|
 | multicorn | 9.3 - 10 |
 | wal2json |  9.4 - 12 |
 | pg-safeupdate | 9.4 - 11 |

--- a/test/postgresql-contrib.bats
+++ b/test/postgresql-contrib.bats
@@ -8,16 +8,15 @@ contrib-only() {
   fi
 }
 
-@test "It should support PLV8" {
+@test "It should support PLV8 1.4.4" {
   contrib-only
   versions-only lt 11
   
   initialize_and_start_pg
-  sudo -u postgres psql --command "CREATE EXTENSION plv8;"
-  sudo -u postgres psql --command "CREATE EXTENSION plls;"
-  sudo -u postgres psql --command "CREATE EXTENSION plcoffee;"
+  sudo -u postgres psql --command "CREATE EXTENSION plv8 VERSION '1.4.4';"
+  sudo -u postgres psql --command "CREATE EXTENSION plls VERSION '1.4.4';"
+  sudo -u postgres psql --command "CREATE EXTENSION plcoffee VERSION '1.4.4';"
 }
-
 
 @test "It should support plpythonu" {
   contrib-only

--- a/test/postgresql-contrib.bats
+++ b/test/postgresql-contrib.bats
@@ -11,11 +11,32 @@ contrib-only() {
 @test "It should support PLV8 1.4.4" {
   contrib-only
   versions-only lt 11
-  
+
   initialize_and_start_pg
   sudo -u postgres psql --command "CREATE EXTENSION plv8 VERSION '1.4.4';"
   sudo -u postgres psql --command "CREATE EXTENSION plls VERSION '1.4.4';"
   sudo -u postgres psql --command "CREATE EXTENSION plcoffee VERSION '1.4.4';"
+}
+
+@test "It should support PLV8 1.4.10" {
+  contrib-only
+  versions-only lt 11
+
+  initialize_and_start_pg
+  sudo -u postgres psql --command "CREATE EXTENSION plv8 VERSION '1.4.10';"
+  sudo -u postgres psql --command "CREATE EXTENSION plls VERSION '1.4.10';"
+  sudo -u postgres psql --command "CREATE EXTENSION plcoffee VERSION '1.4.10';"
+}
+
+@test "It should support upgrading from PLV8 1.4.4 to 1.4.10" {
+  contrib-only
+  versions-only lt 11
+
+  initialize_and_start_pg
+
+  sudo -u postgres psql --command "CREATE EXTENSION plv8 VERSION '1.4.4';"
+  sudo -u postgres psql --command "DROP EXTENSION plv8;"
+  sudo -u postgres psql --command "CREATE EXTENSION plv8 VERSION '1.4.10';"
 }
 
 @test "It should support plpythonu" {


### PR DESCRIPTION
We need to provide a path to upgrade PLV8 for customers, as we cannot upgrade 9.5-contrib, 9.6-contrib, or 10-contrib to Stretch and continue to provide PLV8 1.4.4.

This is a blocker to updating those -contrib images to the latest version of PostgreSQL, which _requires_ switching from jessie to stretch.

- [x] Add test to ensure we can continue to support 1.4.4
- [x] Find a suitable version we can support in jessie and stretch
- [x] Add test that the upgrade from 1.4.4 to that version is possible

PR that moves to Stretch and removes 1.4.4 here : https://github.com/aptible/docker-postgresql/pull/105