### PR TITLE
Add support pgl_ddl_deploy

### DIFF
--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -12,7 +12,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" \
   "^postgresql-${PG_VERSION}-pgaudit$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-repack" "^pgagent$"
+  "^postgresql-${PG_VERSION}-repack" "^pgagent$" "^postgresql-${PG_VERSION}-pgl-ddl-deploy$"
 
 # Now, install source extensions
 

--- a/11-contrib/install-extras.sh
+++ b/11-contrib/install-extras.sh
@@ -12,7 +12,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" \
   "^postgresql-${PG_VERSION}-pgaudit$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-repack" "^pgagent$"
+  "^postgresql-${PG_VERSION}-repack" "^pgagent$" "^postgresql-${PG_VERSION}-pgl-ddl-deploy$"
 
 # Now, install source extensions
 

--- a/12-contrib/install-extras.sh
+++ b/12-contrib/install-extras.sh
@@ -11,7 +11,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plperl-${PG_VERSION}$" "^pgagent$" "^postgresql-${PG_VERSION}-pglogical$" \
   "^postgresql-plpython3-${PG_VERSION}$" "^postgresql-${PG_VERSION}-wal2json$" \
-  "^postgresql-${PG_VERSION}-pgaudit$"
+  "^postgresql-${PG_VERSION}-pgaudit$" "^postgresql-${PG_VERSION}-pgl-ddl-deploy$"
 
 # Now, install source extensions
 

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -11,7 +11,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$" \
-  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$"
+  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$" "^postgresql-${PG_VERSION}-pgl-ddl-deploy$"
 
 # Now, install source extensions
 

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -11,7 +11,7 @@ apt-key add /tmp/GPGkeys/pglogical.key
 # Install packaged extensions first
 apt-install "^postgresql-plpython-${PG_VERSION}$" "^postgresql-plpython3-${PG_VERSION}$" \
   "^postgresql-plperl-${PG_VERSION}$" "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-pgaudit$" \
-  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$"
+  "^postgresql-${PG_VERSION}-wal2json$" "^postgresql-${PG_VERSION}-repack" "^pgagent$" "^postgresql-${PG_VERSION}-pgl-ddl-deploy$"
 
 # Now, install source extensions
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The PostgreSQL server is configured to enforce SSL for any TCP connection. It us
 * `11`: PostgreSQL 11
 * `10`: PostgreSQL 10
 * `9.6`: PostgreSQL 9.6
-* `9.5`: PostgreSQL 9.5
+* `9.5`: PostgreSQL 9.5 (EOL 2021-11-11)
 * `9.4`: PostgreSQL 9.4 (EOL 2020-02-13)
 * `9.3`: PostgreSQL 9.3 (EOL 2018-11-08)
 
@@ -57,6 +57,7 @@ In the `--contrib` images, the following extensions are available.
 | pgagent|  9.4 - 11 |
 | pgaudit |  9.5 - 12 |
 | pgcron | 10 |
+| pgl_ddl_deploy | 9.5 - 12 |
 
 Aptible Support can update your Database to use the `--contrib` image.
 

--- a/test/postgresql-contrib.bats
+++ b/test/postgresql-contrib.bats
@@ -142,3 +142,19 @@ contrib-only() {
   restart_pg
   sudo -u postgres psql --command "CREATE EXTENSION pg_partman;"
 }
+
+@test "It should support pgl-ddl" {
+  contrib-only
+  versions-only ge 9.5
+
+  initialize_and_start_pg
+
+  sudo -u postgres psql --command "ALTER SYSTEM SET shared_preload_libraries='pglogical';"
+  restart_pg
+  
+  sudo -u postgres psql --command "CREATE EXTENSION pglogical;"
+  sudo -u postgres psql --command "CREATE EXTENSION pgl_ddl_deploy;"
+
+  # Be sure 2.0.0 is installed, we'll have to test the upgrade process when a new version is released.
+  dpkg-query --showformat='${Version}' --show "postgresql-${PG_VERSION}-pgl-ddl-deploy" | awk -F '-' '{print $1}' | grep '2.0.0'
+}


### PR DESCRIPTION
This extension provides transparent DDL replication for Postgres 9.5+ for both pglogical and native logical replication.

https://github.com/enova/pgl_ddl_deploy