### PR TITLE
Bump PG versions.

### DIFF
--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.15" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.15"
+@test "It should install PostgreSQL 10.16" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.16"
 }
 
 @test "It should support pg_cron" {

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.15" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.15"
+@test "It should install PostgreSQL 10.16" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.16"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 11.10" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.10"
+@test "It should install PostgreSQL 11.11" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.11"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 11.10" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.10"
+@test "It should install PostgreSQL 11.11" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.11"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 12.5" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.5"
+@test "It should install PostgreSQL 12.6" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.6"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 12.5" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.5"
+@test "It should install PostgreSQL 12.6" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.6"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/13/test/postgresql-13.bats
+++ b/13/test/postgresql-13.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 13.1" {
-  /usr/lib/postgresql/13/bin/postgres --version | grep "13.1"
+@test "It should install PostgreSQL 13.2" {
+  /usr/lib/postgresql/13/bin/postgres --version | grep "13.2"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.6.20" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.20"
+@test "It should install PostgreSQL 9.6.21" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.21"
 }
 
 @test "This image needs to forever support PostGIS 2.3" {

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The PostgreSQL server is configured to enforce SSL for any TCP connection. It us
 * `11`: PostgreSQL 11
 * `10`: PostgreSQL 10
 * `9.6`: PostgreSQL 9.6
-* `9.5`: PostgreSQL 9.5
+* `9.5`: PostgreSQL 9.5 (EOL 2021-02-11)
 * `9.4`: PostgreSQL 9.4 (EOL 2020-02-13)
 * `9.3`: PostgreSQL 9.3 (EOL 2018-11-08)
 


### PR DESCRIPTION
Version 13 has a security-related change we may want to announce on the change blog:

> Fix failure to check per-column SELECT privileges in some join queries (Tom Lane)
> 
> In some cases involving joins, the parser failed to record all the columns read by a query in the column-usage bitmaps that are used for permissions checking. Although the executor would still insist on some sort of SELECT privilege to run the query, this meant that a user having SELECT privilege on only one column of a table could nonetheless read all its columns through a suitably crafted query.
> 
> A stored view that is subject to this problem will have incomplete column-usage bitmaps, and thus permissions will still not be enforced properly on the view after updating. In installations that depend on column-level permissions for security, it is recommended to CREATE OR REPLACE all user-defined views to cause them to be re-parsed.
> 
> The PostgreSQL Project thanks Sven Klemm for reporting this problem. (CVE-2021-20229)

https://www.postgresql.org/docs/release/13.2/
https://www.postgresql.org/docs/release/12.6/
https://www.postgresql.org/docs/release/11.11/
https://www.postgresql.org/docs/release/10.16/
https://www.postgresql.org/docs/release/9.6.21/

