### PR TITLE
Add CA cert to the server chain for Fivetran support.

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -27,6 +27,9 @@ function pg_init_ssl () {
     echo "Certs present in environment - using them"
     echo "$SSL_CERTIFICATE" > "$ssl_cert_file"
     echo "$SSL_KEY" > "$ssl_key_file"
+    if [ -n "$CA_CERTIFICATE" ]; then
+      echo "$CA_CERTIFICATE" >> "$ssl_cert_file"
+    fi
   elif [ -f "$ssl_cert_file" ] && [ -f "$ssl_key_file" ]; then
     echo "Certs present on filesystem - using them"
   else


### PR DESCRIPTION
PostgreSQL says this is optional, but is required for FiveTran to establish trust at the CA level - they do not accept an uploaded CA prior to connecting a database, but rather connect, expect the server to provide the full chain, and ask if you trust the root CA.
