### PR TITLE
Use archive repo for EOL versions.

### DIFF
--- a/9.3/config.mk
+++ b/9.3/config.mk
@@ -3,3 +3,4 @@ export POSTGRES_VERSION = 9.3
 export POSTGIS_VERSION = 2.1
 export AUTH_METHOD = peer
 export PRELOAD_LIB = pg_stat_statements
+export PGDG_ARCHIVE = "-archive"

--- a/9.4/config.mk
+++ b/9.4/config.mk
@@ -3,3 +3,4 @@ export POSTGRES_VERSION = 9.4
 export POSTGIS_VERSION = 2.1
 export AUTH_METHOD = peer
 export PRELOAD_LIB = "pg_stat_statements,pglogical"
+export PGDG_ARCHIVE = "-archive"

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -29,13 +29,14 @@ ENV PG_VERSION <%= ENV.fetch 'POSTGRES_VERSION' %>
 RUN ln -s -f /bin/true /usr/bin/chfn
 
 # Install some helpers we'll need
-RUN apt-install locales wget unzip sudo pwgen \
+RUN apt-install locales wget unzip sudo pwgen apt-transport-https \
     && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 ENV LANG en_US.utf8
 
 # And now install Postgres from its own repos
 ADD templates/etc/apt /etc/apt
-RUN sed -ri  's/__DEBIAN__VERSION__/<%= ENV.fetch 'DEBIAN_VERSION' %>/' /etc/apt/sources.list.d/pgdg.list
+RUN sed -ri 's/__DEBIAN__VERSION__/<%= ENV.fetch 'DEBIAN_VERSION' %>/' /etc/apt/sources.list.d/pgdg.list
+RUN sed -ri 's/__PGDG_ARCHIVE__/<%= ENV.fetch 'PGDG_ARCHIVE' %>/g' /etc/apt/sources.list.d/pgdg.list
 
 # The package names below are anchored, becuase they're interpreted by apt as regexes
 # (because they contain "."), which can result in undesired packages being installed if

--- a/templates/etc/apt/sources.list.d/pgdg.list
+++ b/templates/etc/apt/sources.list.d/pgdg.list
@@ -1,1 +1,2 @@
-deb http://apt.postgresql.org/pub/repos/apt/ __DEBIAN__VERSION__-pgdg main
+deb http://apt__PGDG_ARCHIVE__.postgresql.org/pub/repos/apt/ __DEBIAN__VERSION__-pgdg__PGDG_ARCHIVE__ main
+


### PR DESCRIPTION
I'm not hopeful this will work, but it's an attempt to continue to provide updates to this image. I'm pretty sure it will force breaking changes, which effectively means this EOL versions are no longer supported.