### PR TITLE
Update logical replication to include all non-system dbs and schemas

### DIFF
--- a/10-contrib/test/postgresql-10-contrib.bats
+++ b/10-contrib/test/postgresql-10-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.17" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.17"
+@test "It should install PostgreSQL 10.18" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.18"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {

--- a/10-pg_cron/test/postgresql-10-pg_cron.bats
+++ b/10-pg_cron/test/postgresql-10-pg_cron.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.17" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.17"
+@test "It should install PostgreSQL 10.18" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.18"
 }
 
 @test "It should support pg_cron" {

--- a/10/test/postgresql-10.bats
+++ b/10/test/postgresql-10.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 10.17" {
-  /usr/lib/postgresql/10/bin/postgres --version | grep "10.17"
+@test "It should install PostgreSQL 10.18" {
+  /usr/lib/postgresql/10/bin/postgres --version | grep "10.18"
 }
 
 @test "This image needs to forever support PostGIS 2.4" {

--- a/11-contrib/test/postgresql-11.bats
+++ b/11-contrib/test/postgresql-11.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 11.12" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.12"
+@test "It should install PostgreSQL 11.13" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.13"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/11/test/postgresql-11.bats
+++ b/11/test/postgresql-11.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 11.12" {
-  /usr/lib/postgresql/11/bin/postgres --version | grep "11.12"
+@test "It should install PostgreSQL 11.13" {
+  /usr/lib/postgresql/11/bin/postgres --version | grep "11.13"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/12-contrib/test/postgresql-12.bats
+++ b/12-contrib/test/postgresql-12.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 12.7" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.7"
+@test "It should install PostgreSQL 12.8" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.8"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/12/test/postgresql-12.bats
+++ b/12/test/postgresql-12.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 12.7" {
-  /usr/lib/postgresql/12/bin/postgres --version | grep "12.7"
+@test "It should install PostgreSQL 12.8" {
+  /usr/lib/postgresql/12/bin/postgres --version | grep "12.8"
 }
 
 @test "This image needs to forever support PostGIS 2.5" {

--- a/13-contrib/test/postgresql-13.bats
+++ b/13-contrib/test/postgresql-13.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 13.3" {
-  /usr/lib/postgresql/13/bin/postgres --version | grep "13.3"
+@test "It should install PostgreSQL 13.4" {
+  /usr/lib/postgresql/13/bin/postgres --version | grep "13.4"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/13/test/postgresql-13.bats
+++ b/13/test/postgresql-13.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 13.3" {
-  /usr/lib/postgresql/13/bin/postgres --version | grep "13.3"
+@test "It should install PostgreSQL 13.4" {
+  /usr/lib/postgresql/13/bin/postgres --version | grep "13.4"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/9.6-contrib/test/postgresql-9.6-contrib.bats
+++ b/9.6-contrib/test/postgresql-9.6-contrib.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.6.22" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.22"
+@test "It should install PostgreSQL 9.6.23" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.23"
 }
 
 @test "This image needs to forever support PostGIS 2.3" {

--- a/9.6/test/postgresql-9.6.bats
+++ b/9.6/test/postgresql-9.6.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 9.6.22" {
-  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.22"
+@test "It should install PostgreSQL 9.6.23" {
+  /usr/lib/postgresql/9.6/bin/postgres --version | grep "9.6.23"
 }
 
 @test "This image needs to forever support PostGIS 2.3" {

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -184,35 +184,90 @@ elif [[ "$1" == "--initialize-from-logical" ]]; then
 
   initialize
 
-  parse_url "$master_url"
+  DBS="$(psql "$master_url" --tuples-only --no-align --command 'SELECT datname FROM pg_catalog.pg_database' | grep -v 'template')"
+  NUM_DBS="$(echo "$DBS" | wc -l)"
 
-  PUBLISHER_DSN="host=${host} port=${port} user=${user} password=${password} dbname=${database}"
-  SUBSCRIBER_DSN="host=127.0.0.1 port=${PORT:-"$DEFAULT_PORT"} user=${USERNAME:-aptible} password=${PASSPHRASE} dbname=${DB}"
-  REPLICATION_SET_NAME="aptible_replication_set"
+  echo "Configuring replication for databases:" $DBS
 
+  # Update max_worker_processes to handle multiple databases
+  # Need approximately 1 + number of subscriptions + number of databases for pglogical alone
+  # On a standby server, needs to be at least as many as the master database (default: 8)
   gosu postgres /etc/init.d/postgresql start
-  pg_dump --schema-only --schema public "$master_url" | gosu postgres psql --dbname "${DB}" > /dev/null
 
-  # PG 9.4 primary databases require the pglogical_origin extension to be installed
-  if psql "$master_url" --tuples-only --command "SELECT version()" | grep "PostgreSQL 9.4"; then
-    psql "$master_url" --command "CREATE EXTENSION IF NOT EXISTS pglogical_origin"
+  if [ "$NUM_DBS" > 2 ]; then
+    gosu postgres psql --dbname "${DB}" --command "ALTER SYSTEM SET max_worker_processes = $(( 4 * ${NUM_DBS} ))"
+
+    # Restart the database server to apply the new configuration
+    gosu postgres /etc/init.d/postgresql stop
+    gosu postgres /etc/init.d/postgresql start
   fi
 
-  psql "$master_url" --command "CREATE EXTENSION IF NOT EXISTS pglogical"
-  gosu postgres psql --dbname "${DB}" --command "CREATE EXTENSION IF NOT EXISTS pglogical"
+  parse_url "$master_url"
 
-  # There can only be one node per database
-  # Nodes must have unique names
-  # Nodes can have multiple connection interfaces
-  psql "$master_url" --command "SELECT pglogical.create_node(node_name := 'aptible_publisher', dsn := '${PUBLISHER_DSN}')" \
-    || { echo "Error: Failed to create publisher node. Is there already a pglogical node on the ${database} database?" && exit 1; }
-  gosu postgres psql --dbname "${DB}" --command "SELECT pglogical.create_node(node_name := 'aptible_subscriber', dsn := '${SUBSCRIBER_DSN}')"
+  MASTER_IS_PG_9_4="$(psql "$master_url" --tuples-only --command "SELECT version()" | grep "PostgreSQL 9.4" || true)"
+  REPLICATION_SET_NAME="aptible_replication_set"
 
-  psql "$master_url" --command "SELECT pglogical.create_replication_set(set_name := '${REPLICATION_SET_NAME}')"
-  psql "$master_url" --command "SELECT pglogical.replication_set_add_all_tables('${REPLICATION_SET_NAME}', ARRAY['public'])"
-  psql "$master_url" --command "SELECT pglogical.replication_set_add_all_sequences('${REPLICATION_SET_NAME}', ARRAY['public'])"
-  gosu postgres psql --dbname "${DB}" --command "SELECT pglogical.create_subscription(subscription_name := 'aptible_subscription', provider_dsn := '${PUBLISHER_DSN}', replication_sets := ARRAY['${REPLICATION_SET_NAME}'])"
-  gosu postgres psql --dbname "${DB}" --command "SELECT pglogical.wait_for_subscription_sync_complete('aptible_subscription');"
+  for current_db in $DBS; do
+    echo "Configuring replication for database ${current_db}"
+
+    if [ -z "$(gosu postgres psql --dbname "${DB}" --tuples-only --command "SELECT * FROM pg_catalog.pg_database where datname = '${current_db}'")" ]; then
+      gosu postgres psql --dbname "${DB}" --command "CREATE DATABASE ${current_db} WITH OWNER ${USERNAME:-aptible}"
+    fi
+
+    current_master_url="$(echo "$master_url" | sed "s|/${database}|/${current_db}|")"
+
+    PUBLISHER_DSN="host=${host} port=${port} user=${user} password=${password} dbname=${current_db}"
+    SUBSCRIBER_DSN="host=127.0.0.1 port=${PORT:-"$DEFAULT_PORT"} user=${USERNAME:-aptible} password=${PASSPHRASE} dbname=${current_db}"
+
+    # PG 9.4 primary databases require the pglogical_origin extension to be installed
+    if [ -n "$MASTER_IS_PG_9_4" ]; then
+      psql "$current_master_url" --command "CREATE EXTENSION IF NOT EXISTS pglogical_origin"
+    fi
+
+    psql "$current_master_url" --command "CREATE EXTENSION IF NOT EXISTS pglogical"
+    gosu postgres psql --dbname "${current_db}" --command "CREATE EXTENSION IF NOT EXISTS pglogical"
+
+    # Build SQL array of schemas on the master to replicate
+    # Exclude pg_, information_schema, and pglogical schemas
+    schemas="$(psql "$current_master_url" --tuples-only --no-align --command 'SELECT nspname FROM pg_namespace' | grep -Ev '^(pg_|(information_schema|pglogical(_origin)?)$)')"
+    schema_array=""
+
+    echo "Adding schemas to replication set:" $schemas
+
+    for schema in $schemas; do
+      schema_array="${schema_array},'${schema}'"
+    done
+
+    # Ignore first character in schema_array which is a leading comma
+    schema_array="ARRAY[${schema_array:1}]"
+
+    # There can only be one node per database
+    # Nodes must have unique names
+    psql "$current_master_url" --command "SELECT pglogical.create_node(node_name := 'aptible_publisher', dsn := '${PUBLISHER_DSN}')" \
+      || { echo "Error: Failed to create publisher node. Is there already a pglogical node on the ${current_db} database?" && exit 1; }
+    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.create_node(node_name := 'aptible_subscriber', dsn := '${SUBSCRIBER_DSN}')"
+
+    # Create the replication set with tables and sequences from all of the database's schemas
+    psql "$current_master_url" --command "SELECT pglogical.create_replication_set(set_name := '${REPLICATION_SET_NAME}')"
+    psql "$current_master_url" --command "SELECT pglogical.replication_set_add_all_tables('${REPLICATION_SET_NAME}', ${schema_array})"
+    psql "$current_master_url" --command "SELECT pglogical.replication_set_add_all_sequences('${REPLICATION_SET_NAME}', ${schema_array})"
+
+    # Replicate the replication set we created as well as the ddl_sql replication set
+    # ddl_sql is used by default with the pglogical.replicate_ddl_command function
+    # Do not sync data when the subscription is first created (see below)
+    # synchronize_structure includes creating schemas, tables, and extensions
+    # Extensions are created without specifying a version so the default/latest is used
+    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.create_subscription(subscription_name := 'aptible_subscription', provider_dsn := '${PUBLISHER_DSN}', replication_sets := ARRAY['${REPLICATION_SET_NAME}','ddl_sql'], synchronize_data := FALSE, synchronize_structure := TRUE)"
+    # Wait for the initial sync of the master database's structure
+    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.wait_for_subscription_sync_complete('aptible_subscription');"
+
+    # After the structure sync, initiate the data sync but don't wait for it to complete
+    # pglogical will retry syncing the data each time the container starts until it succeeds
+    # This allows users to access the replica immediately after the structure is synced
+    # If any rows were inserted they'll conflict in the sync so we need to truncate the tables before syncing
+    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.alter_subscription_synchronize('aptible_subscription', truncate := TRUE);"
+  done
+
   gosu postgres /etc/init.d/postgresql stop
 
 elif [[ "$1" == "--initialize-backup" ]]; then

--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -184,7 +184,7 @@ elif [[ "$1" == "--initialize-from-logical" ]]; then
 
   initialize
 
-  DBS="$(psql "$master_url" --tuples-only --no-align --command 'SELECT datname FROM pg_catalog.pg_database' | grep -v 'template')"
+  DBS="$(psql "$master_url" --tuples-only --no-align --command 'SELECT datname FROM pg_catalog.pg_database' | grep -E -v '^template')"
   NUM_DBS="$(echo "$DBS" | wc -l)"
 
   echo "Configuring replication for databases:" $DBS

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -61,67 +61,67 @@ docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_before (c
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_before VALUES ('TEST DATA BEFORE');"
 
 
-echo "Initializing replication slave"
-SLAVE_PORT=54322
-
-docker run -i --rm \
-  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
-  -e APTIBLE_DATABASE_HREF="https://api.aptible.com/databases/8675309" \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG" --initialize-from "$MASTER_URL"
-
-docker run -d --name "$SLAVE_CONTAINER" \
-  -e "PORT=${SLAVE_PORT}" \
-  --volumes-from "$SLAVE_DATA_CONTAINER" \
-  "$IMG"
-
-
-SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
-SLAVE_URL="postgresql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
-
-
-# Wait for slave to come up
-until docker exec -i "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
-
-# Create a test table now that replication has started
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT PRIMARY KEY);"
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
-
-# Give replication a little time. (Hopefully) much more than needed!
-sleep 1
-
-# Check that data is present in both tables
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
-
-
-# The primary database should have a replica slot that corresponds to the replica's database ID.
-# shellcheck disable=SC2016
-if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" gt 9.5'; then
-  docker run -i --rm "$IMG" --client "$MASTER_URL" -c "SELECT slot_name FROM pg_replication_slots;" | grep "aptible_replica_8675309"
-  echo "Replication slot OK"
-fi
-
-echo "Replication set up OK!"
-
-# Set the promote command based on PG version
-if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" ge 12'; then
-  PROMOTE_CMD="SELECT pg_promote();"
-else
-  PROMOTE_CMD="COPY (SELECT 'fast') TO '/var/db/pgsql.trigger';"
-fi
-
-echo "Verify replica is not writeable"
-! docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "INSERT INTO test_after VALUES ('READ ONLY PLEASE');"
-
-echo "Promote the replica"
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "$PROMOTE_CMD"
-sleep 5
-
-echo "Write to promoted replica"
-docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "INSERT INTO test_after VALUES ('WRITE PLEASE');"
-
-echo "Physical replication OK!"
+#echo "Initializing replication slave"
+#SLAVE_PORT=54322
+#
+#docker run -i --rm \
+#  -e USERNAME="$USER" -e PASSPHRASE="$PASSPHRASE" -e DATABASE="$DATABASE" \
+#  -e APTIBLE_DATABASE_HREF="https://api.aptible.com/databases/8675309" \
+#  --volumes-from "$SLAVE_DATA_CONTAINER" \
+#  "$IMG" --initialize-from "$MASTER_URL"
+#
+#docker run -d --name "$SLAVE_CONTAINER" \
+#  -e "PORT=${SLAVE_PORT}" \
+#  --volumes-from "$SLAVE_DATA_CONTAINER" \
+#  "$IMG"
+#
+#
+#SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$SLAVE_CONTAINER")"
+#SLAVE_URL="postgresql://$USER:$PASSPHRASE@$SLAVE_IP:$SLAVE_PORT/$DATABASE"
+#
+#
+## Wait for slave to come up
+#until docker exec -i "$SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
+#
+## Create a test table now that replication has started
+#docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE test_after (col TEXT PRIMARY KEY);"
+#docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER');"
+#
+## Give replication a little time. (Hopefully) much more than needed!
+#sleep 1
+#
+## Check that data is present in both tables
+#docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'
+#docker run -i --rm "$IMG" --client "$SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER'
+#
+#
+## The primary database should have a replica slot that corresponds to the replica's database ID.
+## shellcheck disable=SC2016
+#if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" gt 9.5'; then
+#  docker run -i --rm "$IMG" --client "$MASTER_URL" -c "SELECT slot_name FROM pg_replication_slots;" | grep "aptible_replica_8675309"
+#  echo "Replication slot OK"
+#fi
+#
+#echo "Replication set up OK!"
+#
+## Set the promote command based on PG version
+#if docker run --rm --entrypoint bash "$IMG" -c 'dpkg --compare-versions "$PG_VERSION" ge 12'; then
+#  PROMOTE_CMD="SELECT pg_promote();"
+#else
+#  PROMOTE_CMD="COPY (SELECT 'fast') TO '/var/db/pgsql.trigger';"
+#fi
+#
+#echo "Verify replica is not writeable"
+#! docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "INSERT INTO test_after VALUES ('READ ONLY PLEASE');"
+#
+#echo "Promote the replica"
+#docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "$PROMOTE_CMD"
+#sleep 5
+#
+#echo "Write to promoted replica"
+#docker run -i --rm "$IMG" --client "$SLAVE_URL" -c "INSERT INTO test_after VALUES ('WRITE PLEASE');"
+#
+#echo "Physical replication OK!"
 
 
 # Logical replicaiton
@@ -131,11 +131,12 @@ echo "Initializing master for logical replication"
 # Add additional databases and schemas to the database server to ensure that they are replicated
 OTHER_DB="other_testdb"
 TEST_SCHEMA="test_schema"
+OTHER_USER="other_testuser"
 MASTER_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$OTHER_DB"
 
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE ROLE logical_test;"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE USER $OTHER_USER WITH ENCRYPTED PASSWORD '$PASSPHRASE';"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE logical_test (col TEXT PRIMARY KEY);"
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "ALTER TABLE logical_test OWNER TO logical_test;"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "GRANT SELECT ON logical_test TO $OTHER_USER;"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA BEFORE');"
 
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE SCHEMA $TEST_SCHEMA;"
@@ -172,6 +173,7 @@ docker run -d --name "$LOGICAL_SLAVE_CONTAINER" \
 LOGICAL_SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$LOGICAL_SLAVE_CONTAINER")"
 LOGICAL_SLAVE_URL="postgresql://$USER:$PASSPHRASE@$LOGICAL_SLAVE_IP:$LOGICAL_SLAVE_PORT/$DATABASE"
 LOGICAL_SLAVE_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$LOGICAL_SLAVE_IP:$LOGICAL_SLAVE_PORT/$OTHER_DB"
+LOGICAL_SLAVE_OTHER_USER_URL="postgresql://$OTHER_USER:$PASSPHRASE@$LOGICAL_SLAVE_IP:$LOGICAL_SLAVE_PORT/$DATABASE"
 
 # Wait for slave to come up
 until docker exec -i "$LOGICAL_SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
@@ -282,6 +284,19 @@ docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO $TEST_
 
     if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_DB_URL" -c "SELECT * FROM $TEST_SCHEMA.logical_test;" | grep 'TEST DATA AFTER'; then
       echo "Logical replication on database $OTHER_DB schema $TEST_SCHEMA OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_USER_URL" -c "SELECT * FROM logical_test;" | grep 'TEST DATA AFTER'; then
+      echo "Replication of users and permissions OK!"
       exit
     fi
   done

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -133,7 +133,9 @@ OTHER_DB="other_testdb"
 TEST_SCHEMA="test_schema"
 MASTER_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$OTHER_DB"
 
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE ROLE logical_test;"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE logical_test (col TEXT PRIMARY KEY);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "ALTER TABLE logical_test OWNER TO logical_test;"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA BEFORE');"
 
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE SCHEMA $TEST_SCHEMA;"

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -126,6 +126,28 @@ echo "Physical replication OK!"
 
 # Logical replicaiton
 
+echo "Initializing master for logical replication"
+
+# Add additional databases and schemas to the database server to ensure that they are replicated
+OTHER_DB="other_testdb"
+TEST_SCHEMA="test_schema"
+MASTER_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$OTHER_DB"
+
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE logical_test (col TEXT PRIMARY KEY);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA BEFORE');"
+
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE SCHEMA $TEST_SCHEMA;"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE $TEST_SCHEMA.logical_test (col TEXT PRIMARY KEY);"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO $TEST_SCHEMA.logical_test VALUES ('TEST DATA BEFORE');"
+
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE DATABASE $OTHER_DB;"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "CREATE TABLE logical_test (col TEXT PRIMARY KEY);"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA BEFORE');"
+
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "CREATE SCHEMA $TEST_SCHEMA;"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "CREATE TABLE $TEST_SCHEMA.logical_test (col TEXT PRIMARY KEY);"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO $TEST_SCHEMA.logical_test VALUES ('TEST DATA BEFORE');"
+
 echo "Initializing logical replica data container"
 
 docker create --name "$LOGICAL_SLAVE_DATA_CONTAINER" "$IMG"
@@ -145,10 +167,9 @@ docker run -d --name "$LOGICAL_SLAVE_CONTAINER" \
   --volumes-from "$LOGICAL_SLAVE_DATA_CONTAINER" \
   "$IMG"
 
-
 LOGICAL_SLAVE_IP="$(docker inspect --format '{{ .NetworkSettings.IPAddress }}' "$LOGICAL_SLAVE_CONTAINER")"
 LOGICAL_SLAVE_URL="postgresql://$USER:$PASSPHRASE@$LOGICAL_SLAVE_IP:$LOGICAL_SLAVE_PORT/$DATABASE"
-
+LOGICAL_SLAVE_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$LOGICAL_SLAVE_IP:$LOGICAL_SLAVE_PORT/$OTHER_DB"
 
 # Wait for slave to come up
 until docker exec -i "$LOGICAL_SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; do sleep 0.1; done
@@ -159,8 +180,8 @@ until docker exec -i "$LOGICAL_SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; 
   for _ in {1..25}; do
     sleep 0.2
 
-    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c 'SELECT * FROM test_before;' | grep 'TEST DATA BEFORE'; then
-      echo "Logical replication set up OK!"
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c "SELECT * FROM logical_test;" | grep 'TEST DATA BEFORE'; then
+      echo "Logical replication on database $DATABASE schema public OK!"
       exit
     fi
   done
@@ -168,7 +189,49 @@ until docker exec -i "$LOGICAL_SLAVE_CONTAINER" sudo -u postgres psql -c '\dt'; 
   exit 1
 )
 
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALUES ('TEST DATA AFTER LOGICAL');"
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c "SELECT * FROM $TEST_SCHEMA.logical_test;" | grep 'TEST DATA BEFORE'; then
+      echo "Logical replication on database $DATABASE schema $TEST_SCHEMA OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_DB_URL" -c "SELECT * FROM logical_test;" | grep 'TEST DATA BEFORE'; then
+      echo "Logical replication on database $OTHER_DB schema public OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_DB_URL" -c "SELECT * FROM $TEST_SCHEMA.logical_test;" | grep 'TEST DATA BEFORE'; then
+      echo "Logical replication on database $OTHER_DB schema $TEST_SCHEMA OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA AFTER');"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO $TEST_SCHEMA.logical_test VALUES ('TEST DATA AFTER');"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA AFTER');"
+docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO $TEST_SCHEMA.logical_test VALUES ('TEST DATA AFTER');"
 
 # Give replication a little time.
 # Check that the replica has new data.
@@ -176,8 +239,47 @@ docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO test_after VALU
   for _ in {1..25}; do
     sleep 0.2
 
-    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c 'SELECT * FROM test_after;' | grep 'TEST DATA AFTER LOGICAL'; then
-      echo "Logical replication OK!"
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c "SELECT * FROM logical_test;" | grep 'TEST DATA AFTER'; then
+      echo "Logical replication on database $DATABASE schema public OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_URL" -c "SELECT * FROM $TEST_SCHEMA.logical_test;" | grep 'TEST DATA AFTER'; then
+      echo "Logical replication on database $DATABASE schema $TEST_SCHEMA OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_DB_URL" -c "SELECT * FROM logical_test;" | grep 'TEST DATA AFTER'; then
+      echo "Logical replication on database $OTHER_DB schema public OK!"
+      exit
+    fi
+  done
+
+  exit 1
+)
+
+(
+  for _ in {1..25}; do
+    sleep 0.2
+
+    if docker run -i --rm "$IMG" --client "$LOGICAL_SLAVE_OTHER_DB_URL" -c "SELECT * FROM $TEST_SCHEMA.logical_test;" | grep 'TEST DATA AFTER'; then
+      echo "Logical replication on database $OTHER_DB schema $TEST_SCHEMA OK!"
       exit
     fi
   done


### PR DESCRIPTION
Replicates all databases except those that begin with `template`. Replicates all schemas on the databases except `information_schema`, `pglogical`, `pglogical_origin`, and those that begin with `pg_`.

Roles are also replicated with `pg_dumpall` to prevent issues syncing database structure. Without this any table owned by or permissions for a missing role will throw errors.

pglogical's `synchronize_structure` handles creating all extensions, schemas, tables, and role permissions on the replica database. However, extensions are not created using the same version as the primary database. It appears to use the default (latest?) version so extensions like `postgis` that have breaking changes between versions may not work.