### PR TITLE
Don't truncate tables when syncing with pglogical

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -282,9 +282,8 @@ elif [[ "$1" == "--initialize-from-logical" ]]; then
     # After the structure sync, initiate the data sync but don't wait for it to complete
     # pglogical will retry syncing the data each time the container starts until it succeeds
     # This allows users to access the replica immediately after the structure is synced
-    # If any rows were inserted they'll conflict in the sync so we need to truncate the tables before syncing
     gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.alter_subscription_add_replication_set('aptible_subscription', '${REPLICATION_SET_NAME}');"
-    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.alter_subscription_synchronize('aptible_subscription', truncate := TRUE);"
+    gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.alter_subscription_synchronize('aptible_subscription');"
     # Then re-enable the subscription
     gosu postgres psql --dbname "${current_db}" --command "SELECT pglogical.alter_subscription_enable('aptible_subscription');"
   done

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -151,6 +151,10 @@ docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "CREATE SCHEMA $TES
 docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "CREATE TABLE $TEST_SCHEMA.logical_test (col TEXT PRIMARY KEY);"
 docker run -i --rm "$IMG" --client "$MASTER_OTHER_DB_URL" -c "INSERT INTO $TEST_SCHEMA.logical_test VALUES ('TEST DATA BEFORE');"
 
+# Create a table with a foreign key constraint to ensure tables aren't being truncated
+# A table with a dependent FK constraint cannot be truncated even when empty
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE logical_fk_test (id BIGSERIAL PRIMARY KEY, col TEXT REFERENCES logical_test (col));"
+
 echo "Initializing logical replica data container"
 
 docker create --name "$LOGICAL_SLAVE_DATA_CONTAINER" "$IMG"


### PR DESCRIPTION
I updated the test DB such that it will fail if we accidentally re-enable truncation.