### PR TITLE
Fix bug preventing some roles from being copied during logical replication

### DIFF
--- a/bin/run-database.sh
+++ b/bin/run-database.sh
@@ -211,7 +211,7 @@ elif [[ "$1" == "--initialize-from-logical" ]]; then
 
   # Exclude roles that already exist on the replica or we'll see errors and
   # potentially change its password or permissions unexpectedly
-  current_roles_dump_regex="ROLE ($(gosu postgres psql --dbname "${current_db}" --tuples-only --no-align --command 'SELECT rolname FROM pg_catalog.pg_roles' | tr '\n' '|'))\W"
+  current_roles_dump_regex="ROLE \"?($(gosu postgres psql --dbname "${DB}" --tuples-only --no-align --command 'SELECT rolname FROM pg_catalog.pg_roles' | tr '\n' '|' | sed 's/|$//'))\"?\W"
   pg_dumpall -r -d "$master_url" | grep -E -v "$current_roles_dump_regex" | gosu postgres psql --dbname "${DB}"
 
   for current_db in $DBS; do

--- a/test-replication.sh
+++ b/test-replication.sh
@@ -131,12 +131,12 @@ echo "Initializing master for logical replication"
 # Add additional databases and schemas to the database server to ensure that they are replicated
 OTHER_DB="other_testdb"
 TEST_SCHEMA="test_schema"
-OTHER_USER="other_testuser"
+OTHER_USER="other.testuser"
 MASTER_OTHER_DB_URL="postgresql://$USER:$PASSPHRASE@$MASTER_IP:$MASTER_PORT/$OTHER_DB"
 
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE USER $OTHER_USER WITH ENCRYPTED PASSWORD '$PASSPHRASE';"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE USER \"$OTHER_USER\" WITH ENCRYPTED PASSWORD '$PASSPHRASE';"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE TABLE logical_test (col TEXT PRIMARY KEY);"
-docker run -i --rm "$IMG" --client "$MASTER_URL" -c "GRANT SELECT ON logical_test TO $OTHER_USER;"
+docker run -i --rm "$IMG" --client "$MASTER_URL" -c "GRANT SELECT ON logical_test TO \"$OTHER_USER\";"
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "INSERT INTO logical_test VALUES ('TEST DATA BEFORE');"
 
 docker run -i --rm "$IMG" --client "$MASTER_URL" -c "CREATE SCHEMA $TEST_SCHEMA;"


### PR DESCRIPTION
Role names containing characters that require the name to be wrapped in quotes, e.g. "test.user", were being excluded.