### PR TITLE
Add wal2json to 13-contrib

### DIFF
--- a/13-contrib/config.mk
+++ b/13-contrib/config.mk
@@ -1,4 +1,4 @@
-export DEBIAN_VERSION = stretch
+export DEBIAN_VERSION = buster
 export POSTGRES_VERSION = 13
 export POSTGIS_VERSION = "3"
 export AUTH_METHOD = peer

--- a/13-contrib/install-extras.sh
+++ b/13-contrib/install-extras.sh
@@ -10,4 +10,4 @@ apt-key add /tmp/GPGkeys/pglogical.key
 
 # Install packaged extensions first
 apt-install "^postgresql-${PG_VERSION}-pglogical$" "^pgagent$" "^postgresql-${PG_VERSION}-pgaudit$" \
-            "^postgresql-${PG_VERSION}-repack$"
+            "^postgresql-${PG_VERSION}-repack$" "^postgresql-${PG_VERSION}-wal2json$"

--- a/13-contrib/test/postgresql-13.bats
+++ b/13-contrib/test/postgresql-13.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 13.8" {
-  /usr/lib/postgresql/13/bin/postgres --version | grep "13.8"
+@test "It should install PostgreSQL 13.9" {
+  /usr/lib/postgresql/13/bin/postgres --version | grep "13.9"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In the `-contrib` images, the following extensions are available.
 | mysql_fdw | 9.5 - 11 |
 | PLV8 |  9.5 - 10|
 | multicorn | 9.5 - 10 |
-| wal2json |  9.5 - 12 |
+| wal2json |  9.5 - 13 |
 | pg-safeupdate | 9.5 - 11 |
 | pg_repack | 9.5 - 13 |
 | pgagent | 9.5 - 13 |

--- a/test/postgresql-contrib.bats
+++ b/test/postgresql-contrib.bats
@@ -79,7 +79,7 @@ contrib-only() {
 @test "It should support wal2json" {
   contrib-only
   versions-only ge 9.5
-  versions-only lt 13
+  versions-only lt 14
 
   initialize_and_start_pg
   sudo -u postgres psql --command "ALTER SYSTEM SET wal_level='logical';"


### PR DESCRIPTION
With this change, the 13-contrib image should build (and pass tests), but further work is required to update all image tags to build successfully by either switching to Buster base images or switching to the PGDG APT archives.