### PR TITLE
Updating old images misrepresented as wheezy when base is stretch.

### DIFF
--- a/10-contrib/install-extras.sh
+++ b/10-contrib/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/10-pg_cron/install-extras.sh
+++ b/10-pg_cron/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/10/install-extras.sh
+++ b/10/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/9.5-contrib/install-extras.sh
+++ b/9.5-contrib/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/9.5-pg_cron/install-extras.sh
+++ b/9.5-pg_cron/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/9.5/install-extras.sh
+++ b/9.5/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/9.6-contrib/install-extras.sh
+++ b/9.6-contrib/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key

--- a/9.6/install-extras.sh
+++ b/9.6/install-extras.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 
 # We'll need the pglogical repo...
-echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ wheezy-2ndquadrant main" >> /etc/apt/sources.list
+echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2ndquadrant main" >> /etc/apt/sources.list
 
 # ...and its key
 apt-key add /tmp/GPGkeys/pglogical.key


### PR DESCRIPTION
Old images were updated from wheezy, but repos were not changed they are now all stretch adding in fix. This should resolve upgrade issues we've run into.