### PR TITLE
add pg_repack to v14-16

### DIFF
--- a/14/install-extras.sh
+++ b/14/install-extras.sh
@@ -10,4 +10,11 @@ echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt stretch-2n
 apt-key add /tmp/GPGkeys/pglogical.key
 
 # Install packaged extensions first
-apt-install "^postgresql-${PG_VERSION}-pglogical$"
+apt-install "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-repack$"
+
+DEPS=(
+  build-essential
+  "^postgresql-server-dev-${PG_VERSION}$"
+)
+
+apt-install "${DEPS[@]}"

--- a/15/install-extras.sh
+++ b/15/install-extras.sh
@@ -10,4 +10,11 @@ echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt bullseye-2
 apt-key add /tmp/GPGkeys/pglogical.key
 
 # Install packaged extensions first
-apt-install "^postgresql-${PG_VERSION}-pglogical$"
+apt-install "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-repack$"
+
+DEPS=(
+  build-essential
+  "^postgresql-server-dev-${PG_VERSION}$"
+)
+
+apt-install "${DEPS[@]}"

--- a/15/test/postgresql-15.bats
+++ b/15/test/postgresql-15.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 15.5" {
-  /usr/lib/postgresql/15/bin/postgres --version | grep "15.5"
+@test "It should install PostgreSQL 15.6" {
+  /usr/lib/postgresql/15/bin/postgres --version | grep "15.6"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/16/install-extras.sh
+++ b/16/install-extras.sh
@@ -10,4 +10,11 @@ echo "deb [arch=amd64] https://dl.2ndquadrant.com/default/release/apt bullseye-2
 apt-key add /tmp/GPGkeys/pglogical.key
 
 # Install packaged extensions first
-apt-install "^postgresql-${PG_VERSION}-pglogical$"
+apt-install "^postgresql-${PG_VERSION}-pglogical$" "^postgresql-${PG_VERSION}-repack$"
+
+DEPS=(
+  build-essential
+  "^postgresql-server-dev-${PG_VERSION}$"
+)
+
+apt-install "${DEPS[@]}"

--- a/16/test/postgresql-16.bats
+++ b/16/test/postgresql-16.bats
@@ -2,8 +2,8 @@
 
 source "${BATS_TEST_DIRNAME}/test_helper.sh"
 
-@test "It should install PostgreSQL 16.1" {
-  /usr/lib/postgresql/16/bin/postgres --version | grep "16.1"
+@test "It should install PostgreSQL 16.2" {
+  /usr/lib/postgresql/16/bin/postgres --version | grep "16.2"
 }
 
 @test "This image needs to forever support PostGIS 3" {

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The PostgreSQL server is configured to enforce SSL for any TCP connection. It us
 * `12`: PostgreSQL 12
 * `11`: PostgreSQL 11
 * `10`: PostgreSQL 10
-* `9.6`: PostgreSQL 9.6
+* `9.6`: PostgreSQL 9.6 
 * `9.5`: PostgreSQL 9.5 (EOL 2021-02-11)
 * ~~`9.4`: PostgreSQL 9.4 (EOL 2020-02-13)~~ (Deprecated 2021-05-21)
 * ~~`9.3`: PostgreSQL 9.3 (EOL 2018-11-08)~~ (Deprecated 2021-05-21)
@@ -59,7 +59,7 @@ In the `-contrib` images, the following extensions are available.
 | multicorn | 9.5 - 10 |
 | wal2json |  9.5 - 12 |
 | pg-safeupdate | 9.5 - 11 |
-| pg_repack | 9.5 - 13 |
+| pg_repack | 9.5 - 16 |
 | pgagent | 9.5 - 13 |
 | pgaudit |  9.5 - 13 |
 | pgcron | 10 |


### PR DESCRIPTION
This PR adds pg_repack as an available extension for Postgres 14-16. 